### PR TITLE
 Support for JRE & Oracle (javapath instead of bin)

### DIFF
--- a/src/javaServerStarter.ts
+++ b/src/javaServerStarter.ts
@@ -16,7 +16,7 @@ export function prepareExecutable(requirements: RequirementsData): Executable {
 	options.env = process.env;
 	options.stdio = 'pipe';
 	executable.options = options;
-	executable.command = path.resolve(requirements.java_home + '/bin/java');
+	executable.command = path.resolve(requirements.java_home + '/javapath/java');
 	executable.args = prepareParams(requirements);
 	return executable;
 }

--- a/src/requirements.ts
+++ b/src/requirements.ts
@@ -60,7 +60,7 @@ function checkJavaRuntime(): Promise<string> {
             return resolve(javaHome);
         }
         //No settings, let's try to detect as last resort.
-        findJavaHome(function (err, home) {
+        findJavaHome({allowJre: true}, function (err, home) {
                 if (err){
                     openJDKDownload(reject,'Java runtime could not be located');
                 }
@@ -78,7 +78,7 @@ function readJavaConfig() : string {
  
 function checkJavaVersion(java_home: string): Promise<number> {
     return new Promise((resolve, reject) => {
-        cp.execFile(java_home + '/bin/java', ['-version'], {}, (error, stdout, stderr) => {
+        cp.execFile(java_home + '/javapath/java', ['-version'], {}, (error, stdout, stderr) => {
             let javaVersion = parseMajorVersion(stderr);
             if (javaVersion < 8) {
                 openJDKDownload(reject, 'Java 8 or more recent is required to run. Please download and install a recent JDK.');


### PR DESCRIPTION
This PR is just to show you  how I have fixed the search of java home with my Windows context:

 * no JAVA_HOME path
 * "where java" returns "C:\Program Files (x86)\Common Files\Oracle\Java\javapath\java.exe"
*  javapath is used insteaf of using bin