### PR TITLE
Add default value if workspace configuration is not available

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -89,8 +89,34 @@ export function activate(context: ExtensionContext) {
   function getSettings(): JSON {
     let configXML = workspace.getConfiguration();
     configXML = configXML.get('xml');
-    let x = JSON.stringify(configXML);
-    let settings: JSON = JSON.parse(x);
+    let settings: JSON;
+    if (!configXML) {
+      const defaultValue = {
+        logs: {
+
+        },
+        xml: {
+          trace: {
+            server: 'verbose'
+          },
+          logs: {
+            client: true,
+          },
+          format: {
+            enabled : true,
+            splitAttributes: false
+          },
+          completion: {
+            autoCloseTags: false
+          }
+        }
+      }
+      const x = JSON.stringify(defaultValue);
+      settings = JSON.parse(x);
+    } else {
+      const x = JSON.stringify(configXML);
+      settings = JSON.parse(x);
+    }
     settings['logs']['file'] = logfile;
 
     return settings;


### PR DESCRIPTION
Theia is not implementing the workspace configuration for now (in progress)
So provide a default json value directly instead

Change-Id: Ie3e039954b2a0a20e128145794feaff4d2ea1c63
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>