### PR TITLE
Ensure we filter our selected documents by the file scheme

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,7 +50,10 @@ export function activate(context: ExtensionContext) {
   }).then(requirements => {
     let clientOptions: LanguageClientOptions = {
       // Register the server for xml and xsl
-      documentSelector: ['xml', 'xsl'],
+      documentSelector: [
+        { scheme: 'file', language: 'xml' },
+        { scheme: 'file', language: 'xsl' }
+      ],
       revealOutputChannelOn: RevealOutputChannelOn.Never,
       //wrap with key 'settings' so it can be handled same a DidChangeConfiguration
       initializationOptions: {"settings": getXMLSettings()}, 


### PR DESCRIPTION
We must specify the schemes we're interested in when configuring the language client options. If we don't, we'll get notified of documents on schemes we're not able to handle. For example, when operating in a Git repository, VS Code will send two notifications on file open: one with a `file:///` scheme (which we want) and another with a `git://` scheme (which we don't). Without this change, we'll attempt to handle the latter and fail as lsp4xml won't be able to correctly handle the git URI scheme.