### PR TITLE
Prevent rejected Promise during tag autoclose call

### DIFF
--- a/src/tagClosing.ts
+++ b/src/tagClosing.ts
@@ -63,6 +63,9 @@ export function activateTagClosing(tagProvider: (document: TextDocument, positio
 		timeout = setTimeout(() => {
 			let position = new Position(rangeStart.line, rangeStart.character + lastChange.text.length);
 			tagProvider(document, position).then(result => {
+				if (!result) {
+					return;
+				}
 				let text = result.snippet;
 				let replaceLocation : Position | Range;
 				let range : Range = result.range;


### PR DESCRIPTION
Fixes rejected promise not handled within 1 second: TypeError: Cannot read property 'snippet' of null
extensionHostProcess.js:706
stack trace: TypeError: Cannot read property 'snippet' of null
extensionHostProcess.js:706
	at tagProvider.then.result (/path/to/vscode-xml/out/src/tagClosing.js:59:35)