### PR TITLE
JRE support

### DIFF
--- a/src/requirements.ts
+++ b/src/requirements.ts
@@ -8,7 +8,7 @@ const pathExists = require('path-exists');
 const expandHomeDir = require('expand-home-dir');
 const findJavaHome = require('find-java-home');
 const isWindows = process.platform.indexOf('win') === 0;
-const JAVAC_FILENAME = 'javac' + (isWindows?'.exe':'');
+const JAVA_FILENAME = 'java' + (isWindows?'.exe':'');
 
 export interface RequirementsData {
     java_home: string;
@@ -54,7 +54,7 @@ function checkJavaRuntime(): Promise<string> {
             if(!pathExists.sync(javaHome)){
                 openJDKDownload(reject, source+' points to a missing folder');
             }
-            if(!pathExists.sync(path.resolve(javaHome, 'bin', JAVAC_FILENAME))){
+            if(!pathExists.sync(path.resolve(javaHome, 'bin', JAVA_FILENAME))){
                 openJDKDownload(reject, source+ ' does not point to a JDK.');
             }
             return resolve(javaHome);


### PR DESCRIPTION
Only JDK is supported. Generally users who don't develop with Java, have an installed JRE not a JDK. I think javac is used here because it was a copy/paste from jdt ls code which requires JDK.

This very simple PR checks if java exists and not javac. But it requires to declare the JRE with java.home. It should be improved to find JRE like we have that with JDK.