### PR TITLE
Registers language server for newly created unsaved XML files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,7 +52,9 @@ export function activate(context: ExtensionContext) {
       // Register the server for xml and xsl
       documentSelector: [
         { scheme: 'file', language: 'xml' },
-        { scheme: 'file', language: 'xsl' }
+        { scheme: 'file', language: 'xsl' },
+        { scheme: 'untitled', language: 'xml' },
+        { scheme: 'untitled', language: 'xsl' }
       ],
       revealOutputChannelOn: RevealOutputChannelOn.Never,
       //wrap with key 'settings' so it can be handled same a DidChangeConfiguration


### PR DESCRIPTION
Very likely fixes the cause of #154 

When creating a new file (without saving) and setting the language mode to XML, no requests were being sent to the language server.

This PR allows requests to be sent for files that are not saved on the local file system.

Signed-off-by: David Kwon <dakwon@redhat.com>