### PR TITLE
XSD CodeLens references should be clickable

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,33 @@
+/**
+ *  Copyright (c) 2019 Red Hat, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Red Hat Inc. - initial API and implementation
+ */
+'use strict';
+
+/**
+ * Commonly used commands
+ */
+export namespace Commands {
+ 
+    /**
+     * Auto close tags
+     */
+    export const AUTO_CLOSE_TAGS= 'xml.completion.autoCloseTags';
+
+    /**
+     * Show XML references
+     */
+    export const SHOW_REFERENCES = 'xml.show.references';
+
+    /**
+     * Show editor references
+     */
+    export const EDITOR_SHOW_REFERENCES = 'editor.action.showReferences';
+
+}


### PR DESCRIPTION
See https://github.com/angelozerr/lsp4xml/issues/490

This PR binds the XSD CodeLens references command to a function which
opens the vscode references.