### PR TITLE
.ent and .mod files should be parsed as DTDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "keywords": [
     "xml",
     "xsl",
-    "xsd"
+    "xsd",
+    "dtd"
   ],
   "engines": {
     "vscode": "^1.27.0"
@@ -263,6 +264,15 @@
       "[xml]": {
         "editor.autoClosingBrackets": "never"
       }
-    }
+    },
+    "languages": [
+      {
+        "id": "xml",
+        "extensions": [
+          ".ent",
+          ".mod"
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
See https://github.com/angelozerr/lsp4xml/issues/380

Signed-off-by: azerr <azerr@redhat.com>