### PR TITLE
Update CHANGELOG for 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Change Log
 
+## [0.10.0](https://github.com/angelozerr/lsp4xml/milestone/11?closed=1) (December 11, 2019)
+
+### Enhancements
+
+* (Experimental) Ability to edit start/end tag simultaneously under `xml.mirrorCursorOnMatchingTag` preference. Can be toggled on/off on Windows/Linux through `ctrl+shift+f2` and on Mac `cmd+shift+f2`. See [#130](https://github.com/redhat-developer/vscode-xml/issues/130).
+* Allows File Associations to be used without Workspace. See [#202](https://github.com/redhat-developer/vscode-xml/issues/202).
+* CodeAction for missing root end tag. See [#lsp4xml/595](https://github.com/angelozerr/lsp4xml/pull/595).
+* DTD hover/completion support for documentation. See [#lsp4xml/592](https://github.com/angelozerr/lsp4xml/pull/592).
+* CodeAction for similar looking element names if it doesn't match the schema. See [#lsp4xml/591](https://github.com/angelozerr/lsp4xml/pull/591).
+* Navigation and intellisense for xs:include-ed types. See [#lsp4xml/579](https://github.com/angelozerr/lsp4xml/pull/579).
+* Contribute to completion, hover .. with external JAR. See [#193](https://github.com/redhat-developer/vscode-xml/pull/193).
+* Added documentation on how to contribute extensions to the XML LS. See [#197](https://github.com/redhat-developer/vscode-xml/pull/197).
+
+
+### Bug Fixes
+
+* xs:import code action was inserting inside the tag name. See [#lsp4xml/593](https://github.com/angelozerr/lsp4xml/pull/593).
+* Prolog attribute completion was providing invalid values. See [#lsp4xml/587](https://github.com/angelozerr/lsp4xml/pull/587).
+* getCurrentAttribute method was not returning the correct attribute name. See [#lsp4xml/584](https://github.com/angelozerr/lsp4xml/pull/584).
+* Hover was not returning all hover responses. See [#lsp4xml/582](https://github.com/angelozerr/lsp4xml/pull/582).
+* cvc-pattern error range fix. See [#lsp4xml/580](https://github.com/angelozerr/lsp4xml/pull/580).
+
 ## [0.9.1](https://github.com/redhat-developer/vscode-xml/milestone/11?closed=1) (October 17, 2019)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -71,14 +71,17 @@ The following settings are supported:
 * `xml.validation.schema`: Set to `false` to disable schema validation. Defaults to `true`.
 * `xml.validation.noGrammar`: The message severity when a document has no associated grammar. Defaults to `hint`.
 * `xml.server.workDir`: Set an absolute path for all cached schemas to be stored. Defaults to `~/.lsp4xml`.
-  
-Since 0.8.0:
 * `xml.codeLens.enabled`: Enable/disable XML CodeLens. Default is `false`.
 * `xml.symbols.excluded`: Disable document symbols (Outline) for the given file name patterns. Updating file name patterns does not automatically reload the Outline view for the relevant file(s). Each file must either be reopened or changed, in order to trigger an Outline view reload.
 
 Since 0.9.1:
 * `xml.validation.disallowDocTypeDecl`: Enable/disable if a fatal error is thrown if the incoming document contains a DOCTYPE declaration. Default is `false`.
 * `xml.validation.resolveExternalEntities`: Enable/disable resolve of external entities. Default is `false`.
+
+Since 0.10.0:
+* `xml.mirrorCursorOnMatchingTag`: (Experimental) Enable/disable ability to simultaneously edit the start and end tag of an element. Default is `true`. Can be toggled on/off on Windows/Linux through `ctrl+shift+f2` and on Mac `cmd+shift+f2`.
+  * **Note**: XML tag name completion is currently not working with mirror cursors on.
+  * **Note**: In a multi-root workspace, cursors do not immediately enable or disable when editing XML files located in separate workspace folders.
         
 ## Custom XML Extensions
 


### PR DESCRIPTION
Renamed xml.matchingTagEditing to xml.mirrorCursorOnMatchingTag, and added (Experimental)

This PR adds onto this PR: https://github.com/redhat-developer/vscode-xml/pull/206