### PR TITLE
Gracefully handle cancel 'xml/closeTag' requests

### DIFF
--- a/src/tagClosing.ts
+++ b/src/tagClosing.ts
@@ -90,6 +90,8 @@ export function activateTagClosing(tagProvider: (document: TextDocument, positio
 						}
 					}
 				}
+			}, (reason: any) => {
+				console.log('xml/closeTag request has been cancelled');
 			});
 			timeout = void 0;
 		}, 100);


### PR DESCRIPTION
Fixes #149 

This PR adds a `onRejected()` function to the `Thenable` that sends the `xml/closeTag` request.

Before this PR:
![image](https://user-images.githubusercontent.com/20326645/71913448-6e39af00-3145-11ea-9126-19d349500cee.png)

After this PR:
![image](https://user-images.githubusercontent.com/20326645/71913444-6bd75500-3145-11ea-8e9e-347e9698960c.png)

Signed-off-by: David Kwon <dakwon@redhat.com>