### PR TITLE
[WIP] run a binary server

### DIFF
--- a/src/requirements.ts
+++ b/src/requirements.ts
@@ -30,6 +30,7 @@ interface ErrorData {
  *
  */
 export async function resolveRequirements(context: ExtensionContext): Promise<RequirementsData> {
+    //TODO Handle different requirements if using binary
     const javaHome = await checkJavaRuntime(context);
     const javaVersion = await checkJavaVersion(javaHome);
     return Promise.resolve({ 'java_home': javaHome, 'java_version': javaVersion});


### PR DESCRIPTION
requires https://github.com/eclipse/lemminx/pull/673

Add those preferences to your settings.json:

```
 "xml.server.binary.enabled":true,
 "xml.server.binary.path":"/path/to/org.eclipse.lemminx/target/lemminx-{platform}-0.12.0-SNAPSHOT"
```

Alternatively, you can copy the lemminx binary inside the vscode-xml/server directory, then "xml.server.binary.path" can be omitted.