### PR TITLE
Process create file requests from server

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -26,6 +26,11 @@ export namespace Commands {
     export const SHOW_REFERENCES = 'xml.show.references';
 
     /**
+     * Apply the given WorkspaceEdit
+     */
+    export const APPLY_WORKSPACE_EDIT = 'xml.apply.workspaceEdit';
+
+    /**
      * Show editor references
      */
     export const EDITOR_SHOW_REFERENCES = 'editor.action.showReferences';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@
 import { prepareExecutable } from './javaServerStarter';
 import { LanguageClientOptions, RevealOutputChannelOn, LanguageClient, DidChangeConfigurationNotification, RequestType, TextDocumentPositionParams, ReferencesRequest, NotificationType, MessageType } from 'vscode-languageclient';
 import * as requirements from './requirements';
-import { languages, IndentAction, workspace, window, commands, ExtensionContext, TextDocument, Position, LanguageConfiguration, Uri, extensions, Command } from "vscode";
+import { languages, IndentAction, workspace, window, commands, ExtensionContext, TextDocument, Position, LanguageConfiguration, Uri, extensions, Command, WorkspaceEdit } from "vscode";
 import * as path from 'path';
 import * as os from 'os';
 import { activateTagClosing, AutoCloseResult } from './tagClosing';
@@ -122,6 +122,13 @@ export function activate(context: ExtensionContext) {
           })
         })
       }));
+
+      context.subscriptions.push(commands.registerCommand(Commands.APPLY_WORKSPACE_EDIT, async (obj) => {
+        const edit: WorkspaceEdit = languageClient.protocol2CodeConverter.asWorkspaceEdit(obj);
+        if (edit) {
+          await workspace.applyEdit(edit);
+        }
+      }))
 
       setupActionableNotificationListener(languageClient);
 


### PR DESCRIPTION
Adapt the client to respond to the `xml.apply.workspaceEdit`
command from the server in order to allow the server to
create files. The implementation is based off of `vscode-java`.

Please refer to the server behaviour:
https://github.com/eclipse/lemminx/pull/783

Signed-off-by: David Thompson <davthomp@redhat.com>