### PR TITLE
Dispose extensions did change listener when deactivated

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -138,9 +138,9 @@ export function activate(context: ExtensionContext) {
       context.subscriptions.push(activateTagClosing(tagProvider, { xml: true, xsl: true }, Commands.AUTO_CLOSE_TAGS));
 
       if (extensions.onDidChange) {// Theia doesn't support this API yet
-        extensions.onDidChange(() => {
+        context.subscriptions.push(extensions.onDidChange(() => {
           onExtensionChange(extensions.all);
-        });
+        }));
       }
 
     });


### PR DESCRIPTION
Noticed this when working on vscode-microprofile :) 

Disposes the `extensions.onDidChange` event listener if vscode-xml is deactivated / uninstalled.

Signed-off-by: Ryan Zegray <ryan.zegray@ibm.com>