### PR TITLE
Bump version to 0.14.0 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-xml",
   "displayName": "XML",
   "description": "XML Language Support by Red Hat",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "author": "Red Hat",
   "publisher": "redhat",
   "icon": "icons/icon128.png",


### PR DESCRIPTION
Change from https://github.com/redhat-developer/vscode-xml/pull/293#discussion_r465303555

Ups the version to 0.14.0 in the package.json. It is set to that in package-lock, but package lock version gets overwritten when running npm install

Signed-off-by: Ryan Zegray <ryan.zegray@ibm.com>