### PR TITLE
Fix warnings in extension host

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -51,7 +51,7 @@ export function subscribeJDKChangeConfiguration() {
       oldXMLConfig = newXMLConfig;
       return;
     }
-    
+
     //handle "java.home" change
     if(oldXMLConfig.get("java.home") == null) { // if "xml.java.home" exists, dont even look at "java.home"
       if(params.affectsConfiguration("java")) {
@@ -99,9 +99,15 @@ function verifyVMArgs() {
 }
 
 function verifyAutoClosing() {
-  let configXML = workspace.getConfiguration();
-  let closeTags = configXML.get("xml.completion.autoCloseTags");
-  let closeBrackets = configXML.get("[xml]")["editor.autoClosingBrackets"];
+  let closeTags = getXMLConfiguration().get("completion.autoCloseTags");
+  /*
+   * HACK: the second parameter has changed in newer API:
+   * https://github.com/microsoft/vscode/blob/40827f365c376dd6753116326fd10a9f826655b7/src/vs/vscode.d.ts#L9965
+   * In order to avoid warnings about accessing a resource-specific config,
+   * since [xml] only applies if the document is an xml document,
+   * a null document value is passed.
+   */
+  let closeBrackets = workspace.getConfiguration("[xml]", null)["editor.autoClosingBrackets"];
   if (closeTags && closeBrackets != "never") {
     window.showWarningMessage(
       "The [xml].editor.autoClosingBrackets setting conflicts with xml.completion.autoCloseTags. It's recommended to disable it.",

--- a/src/tagClosing.ts
+++ b/src/tagClosing.ts
@@ -1,7 +1,7 @@
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
- * 
+ *
  *  Retrieved from: https://github.com/Microsoft/vscode/blob/f707828426bd87e88c17d2da34f2ceed0019d8bd/extensions/html-language-features/client/src/tagClosing.ts
  *--------------------------------------------------------------------------------------------*/
 'use strict';
@@ -34,7 +34,7 @@ export function activateTagClosing(tagProvider: (document: TextDocument, positio
 		if (!supportedLanguages[document.languageId]) {
 			return;
 		}
-		if (!workspace.getConfiguration(void 0, document.uri).get<boolean>(configName)) {
+		if (!workspace.getConfiguration().get<boolean>(configName)) {
 			return;
 		}
 		isEnabled = true;
@@ -86,7 +86,6 @@ export function activateTagClosing(tagProvider: (document: TextDocument, positio
 						let activeDocument = activeEditor.document;
 						if (document === activeDocument && activeDocument.version === version) {
 							activeEditor.insertSnippet(new SnippetString(text), replaceLocation);
-							
 						}
 					}
 				}


### PR DESCRIPTION
Use method described by Eskibear to access [xml] autoclosing settings.
Do not provide a document when accessing vscode-xml settings, since LemMinX doesn't support multi-root projects right now.

Closes #98

Signed-off-by: David Thompson <davthomp@redhat.com>