### PR TITLE
Allow globs in `xml.javaExtensions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,23 @@ To do that:
 
 ```json
 "contributes": {
-	"xml.javaExtensions": [
-		"./jar/your-custom-xml-extension.jar"
-	]
+  "xml.javaExtensions": [
+    "./jar/your-custom-xml-extension.jar"
+  ]
 }
 ```
+
+  * You can also list multiple jars or use glob patterns to specify the jars:
+
+```json
+"contributes": {
+  "xml.javaExtensions": [
+    "./jar/dependencies/*.jar",
+    "./jar/my-xml-extension.jar"
+  ]
+}
+```
+
 
 You can see the [vscode-xml-maven](https://github.com/angelozerr/vscode-xml-maven) sample which registers custom maven completion [MavenCompletionParticipant](https://github.com/angelozerr/lsp4xml-extensions-maven/blob/master/org.eclipse.lsp4xml.extensions.maven/src/main/java/org/eclipse/lsp4xml/extensions/maven/MavenCompletionParticipant.java#L28) for scope:
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3,6 +3,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { Commands } from './commands';
+const glob = require('glob');
 
 let existingExtensions: Array<string>;
 
@@ -15,7 +16,7 @@ export function collectXmlJavaExtensions(extensions: readonly vscode.Extension<a
 				const xmlJavaExtensions = contributesSection['xml.javaExtensions'];
 				if (Array.isArray(xmlJavaExtensions) && xmlJavaExtensions.length) {
 					for (const xmLJavaExtensionPath of xmlJavaExtensions) {
-						result.push(path.resolve(extension.extensionPath, xmLJavaExtensionPath));
+						result.push(...glob.sync(path.resolve(extension.extensionPath, xmLJavaExtensionPath)));
 					}
 				}
 			}


### PR DESCRIPTION
Paths supplied to `xml.javaExtensions` will be treated as globs.

To test, I took [vscode-lemminx-maven](https://github.com/angelozerr/vscode-xml-maven), modified `xml.javaExtensions` in `package.json` to `./jar/*.jar`, then added the [liquidbase lemminx extension uber](https://github.com/Treehopper/liquibase-lsp/releases) into `./jar`. Both `pom.xml` and [this liquidbase example (first one)](https://www.liquibase.org/get-started/best-practices) received validation:

![Screenshot from 2020-09-10 11-48-03](https://user-images.githubusercontent.com/22376627/92759521-d805fa80-f35d-11ea-8dd7-c75c2e7e9787.png)

![Screenshot from 2020-09-10 12-05-30](https://user-images.githubusercontent.com/22376627/92759612-efdd7e80-f35d-11ea-9153-df2ed5ec3917.png)

Signed-off-by: David Thompson <davthomp@redhat.com>