### PR TITLE
Respond to requests for indentation settings

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,9 +11,9 @@
  */
 
 import { prepareExecutable } from './javaServerStarter';
-import { LanguageClientOptions, RevealOutputChannelOn, LanguageClient, DidChangeConfigurationNotification, RequestType, TextDocumentPositionParams, ReferencesRequest, NotificationType, MessageType } from 'vscode-languageclient';
+import { LanguageClientOptions, RevealOutputChannelOn, LanguageClient, DidChangeConfigurationNotification, RequestType, TextDocumentPositionParams, ReferencesRequest, NotificationType, MessageType, ConfigurationRequest, ConfigurationParams } from 'vscode-languageclient';
 import * as requirements from './requirements';
-import { languages, IndentAction, workspace, window, commands, ExtensionContext, TextDocument, Position, LanguageConfiguration, Uri, extensions, Command } from "vscode";
+import { languages, IndentAction, workspace, window, commands, ExtensionContext, TextDocument, Position, LanguageConfiguration, Uri, extensions, Command, TextEditor } from "vscode";
 import * as path from 'path';
 import * as os from 'os';
 import { activateTagClosing, AutoCloseResult } from './tagClosing';
@@ -248,6 +248,25 @@ export function activate(context: ExtensionContext) {
           onExtensionChange(extensions.all);
         }));
       }
+
+      // Copied from:
+      // https://github.com/redhat-developer/vscode-java/pull/1081/files
+      languageClient.onRequest(ConfigurationRequest.type, (params: ConfigurationParams) => {
+        const result: any[] = [];
+        const activeEditor: TextEditor | undefined = window.activeTextEditor;
+        for (const item of params.items) {
+          if (activeEditor && activeEditor.document.uri.toString() === Uri.parse(item.scopeUri).toString()) {
+            if (item.section === "xml.format.insertSpaces") {
+              result.push(activeEditor.options.insertSpaces);
+            } else if (item.section === "xml.format.tabSize") {
+              result.push(activeEditor.options.tabSize);
+            }
+          } else {
+            result.push(workspace.getConfiguration(null, Uri.parse(item.scopeUri)).get(item.section));
+          }
+        }
+        return result;
+      });
 
       const api: XMLExtensionApi = {
         // add API set catalogs to internal memory


### PR DESCRIPTION
Uses requests to the preferences `xml.format.insertSpaces` and `xml.format.tabSize` to provide the indentation of the current file to the server.

Copied from: https://github.com/redhat-developer/vscode-java/pull/1081/files

Along with eclipse/lemminx#903, closes #267

Signed-off-by: David Thompson <davthomp@redhat.com>
