### PR TITLE
Support 'xml/executeClientCommand' request

### DIFF
--- a/docs/Extensions.md
+++ b/docs/Extensions.md
@@ -40,3 +40,9 @@ You can see the [vscode-xml-maven](https://github.com/angelozerr/vscode-xml-mave
 ## XML extension API (TypeScript)
 
 See [PR 292](https://github.com/redhat-developer/vscode-xml/pull/292)
+
+### Commands
+
+`xml.workspace.executeCommand` - command registered on VSCode client (via **vscode-xml** extension) to let other extensions execute commands on XML Language server
+
+`xml/executeClientCommand` - XML Language server LSP extension to let XML LS extenders execute commands on the client. The command is made available via `IXMLCommandService` on the server side. See [XML LS extensions docs](https://github.com/eclipse/lemminx/blob/master/docs/LemMinX-Extensions.md#xml-language-server-services-available-for-extensions)

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -50,4 +50,9 @@ export namespace Commands {
     export const OPEN_DOCS = "xml.open.docs";
 
     export const OPEN_DOCS_HOME = "xml.open.docs.home";
+    
+    /**
+     * VSCode client command to executes an LSP command on the XML Language Server
+     */
+    export const EXECUTE_WORKSPACE_COMMAND = "xml.workspace.executeCommand";
 }


### PR DESCRIPTION
Handle the 'xml/executeClientCommand' request by executing the corresponding vscode command