### PR TITLE
Simplify XML preferences category

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   "contributes": {
     "configuration": {
       "type": "object",
-      "title": "XML configuration",
+      "title": "XML",
       "properties": {
         "xml.java.home": {
           "type": [


### PR DESCRIPTION
Drop "configuration" from the XML preferences category to align with other extensions.

See https://github.com/redhat-developer/vscode-java/issues/1227