### PR TITLE
cleanup for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ This VS Code extension provides support for creating and editing XML documents, 
   * Symbol highlighting
   * Document folding
   * Document links
-  * Document symbols and outline (see [Outline](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Symbols.md))
+  * [Document symbols and outline](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Symbols.md)
   * Renaming support
-  * Document Formatting (see [formatting settings](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Formatting.md))
-  * DTD validation
+  * [Document Formatting](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Formatting.md)
+  * [DTD validation](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Validation.md#validation-with-dtd-grammar)
   * DTD completion
   * DTD formatting
-  * XSD validation
+  * [XSD validation](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Validation.md#validation-with-xsd-grammar)
   * XSD based hover
   * XSD based code completion
   * XSL support
-  * XML catalogs
+  * [XML catalogs](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Validation.md#xml-catalog-with-xsd)
   * File associations
   * Code actions
   * Schema Caching
@@ -37,7 +37,7 @@ See the [changelog](CHANGELOG.md) for the latest release.
 You might also find useful information in the [Online XML Documentation](https://github.com/redhat-developer/vscode-xml/blob/master/docs/README.md) 
 or you can read this documentation inside vscode with the command `Open XML Document` available with `Ctrl+Shift+P`:
 
-![XML Open Documentation](docs/images/Commands/XMLCommands.png)
+![XML Open Documentation](https://raw.githubusercontent.com/redhat-developer/vscode-xml/master/docs/images/Commands/XMLCommands.png)
 
 ## Requirements
 
@@ -56,70 +56,42 @@ See [how to set java home](https://github.com/redhat-developer/vscode-xml/blob/m
 
 The following settings are supported:
 
-* `xml.java.home`: Set the Java path required to run the XML Language Server. If not set, falls back  to either the `java.home` preference or the `JAVA_HOME` or `JDK_HOME` environment variables. 
-See [here](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Preferences.md#java-home) for more information.
-* `xml.server.vmargs`: Specifies extra VM arguments used to launch the XML Language Server. Eg. use `-Xmx1G  -XX:+UseG1GC -XX:+UseStringDeduplication` to bypass class verification, increase the heap size to 1GB and enable String deduplication with the G1 Garbage collector. 
-See [here](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Preferences.md#server-vm-arguments) for more information.
-* `xml.server.workDir`: Set a custom folder path for cached XML Schemas. An absolute path is expected, although the `~` prefix (for the user home directory) is supported. Default is `~/.lemminx`. 
-See [here](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Preferences.md#server-cache-path) for more information.
-* `xml.trace.server` : Trace the communication between VS Code and the XML language server in the Output view. Default is `off`.
-* `xml.logs.client` : Enable/disable logging to the Output view. Default is `true`.
-
-* `xml.catalogs` : Register XML catalog files. 
-See [here](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Preferences.md#catalogs) for more information.
-* `xml.fileAssociations` : Allows XML schemas/ DTD to be associated to file name patterns. 
-See [here](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Preferences.md#file-associations) for more information.
-
-* `xml.format.enabled` : Enable/disable ability to format document. Default is `true`. 
-See [here](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Formatting.md#xmlformatenabled) for more information.
-* `xml.format.emptyElements` : Expand/collapse empty elements. Default is `ignore`. 
-See [here](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Formatting.md#xmlformatemptyelements) for more information.
-* `xml.format.enforceQuoteStyle`: Enforce `preferred` quote style (set by `xml.preferences.quoteStyle`) or `ignore` quote style when formatting. Default is `ignore`. 
-See [here](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Formatting.md#xmlformatenforcequotestyle) for more information.
-* `xml.format.joinCDATALines` : Set to `true` to join lines in CDATA content during formatting. Default is `false`. 
-See [here](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Formatting.md#xmlformatjoincdatalines) for more information.
-* `xml.format.joinCommentLines` : Set to `true` to join lines in comments during formatting. Default is `false`. 
-See [here](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Formatting.md#xmlformatjoincommentlines) for more information.
-* `xml.format.joinContentLines` : Normalize the whitespace of content inside an element. Newlines and excess whitespace are removed. Default is `false`. See [here](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Formatting.md#xmlformatjoincontentlines) for more information.
-* `xml.format.preserveAttributeLineBreaks`: Preserve line breaks that appear before and after attributes. This setting is overridden if `xml.format.splitAttributes` is set to `true`. Default is `false`. 
-See [here](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Formatting.md#xmlformatpreserveattributelinebreaks) for more information.
-* `xml.format.preserveEmptyContent`: Preserve empty content/whitespace in a tag. Default is `false`. 
-See [here](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Formatting.md#xmlformatpreserveemptycontent) for more information.
-* `xml.format.preservedNewLines`: Preserve new lines that separate tags. The value represents the maximum number of new lines per section. A value of 0 removes all new lines. Default is `2`. 
-See [here](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Formatting.md#xmlformatpreservednewlines) for more information.
-* `xml.format.spaceBeforeEmptyCloseTag`: Insert space before end of self closing tag. \nExample:\n  ```<tag/> -> <tag />```. Default is `true`. 
-See [here](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Formatting.md#xmlformatspacebeforeemptyclosetag) for more information.
-* `xml.format.splitAttributes` : Split multiple attributes each onto a new line. Default is `false`. 
-See [here](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Formatting.md#xmlformatsplitattributes) for more information.
+* [`xml.java.home`](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Preferences.md#java-home): Set the Java path required to run the XML Language Server. If not set, falls back  to either the `java.home` preference or the `JAVA_HOME` or `JDK_HOME` environment variables.
+* [`xml.server.vmargs`](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Preferences.md#server-vm-arguments): Specifies extra VM arguments used to launch the XML Language Server.  
+   Eg. use `-Xmx1G  -XX:+UseG1GC -XX:+UseStringDeduplication` to bypass class verification, increase the heap size to 1GB and enable String deduplication with the G1 Garbage collector.
+* [`xml.server.workDir`](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Preferences.md#server-cache-path): Set a custom folder path for cached XML Schemas. An absolute path is expected, although the `~` prefix (for the user home directory) is supported. Default is `~/.lemminx`.
+* `xml.trace.server`: Trace the communication between VS Code and the XML language server in the Output view. Default is `off`.
+* `xml.logs.client`: Enable/disable logging to the Output view. Default is `true`.
+* [`xml.catalogs`](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Preferences.md#catalogs): Register XML catalog files.
+* [`xml.fileAssociations`](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Preferences.md#file-associations): Allows XML schemas/ DTD to be associated to file name patterns.
+* [`xml.format.enabled`](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Formatting.md#xmlformatenabled): Enable/disable ability to format document. Default is `true`.
+* [`xml.format.emptyElements`](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Formatting.md#xmlformatemptyelements): Expand/collapse empty elements. Default is `ignore`.
+* [`xml.format.enforceQuoteStyle`](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Formatting.md#xmlformatenforcequotestyle): Enforce `preferred` quote style (set by `xml.preferences.quoteStyle`) or `ignore` quote style when formatting. Default is `ignore`.
+* [`xml.format.joinCDATALines`](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Formatting.md#xmlformatjoincdatalines): Set to `true` to join lines in CDATA content during formatting. Default is `false`.
+* [`xml.format.joinCommentLines`](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Formatting.md#xmlformatjoincommentlines): Set to `true` to join lines in comments during formatting. Default is `false`.
+* [`xml.format.joinContentLines`](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Formatting.md#xmlformatjoincontentlines): Normalize the whitespace of content inside an element. Newlines and excess whitespace are removed. Default is `false`.
+* [`xml.format.preserveAttributeLineBreaks`](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Formatting.md#xmlformatpreserveattributelinebreaks): Preserve line breaks that appear before and after attributes. Default is `false`.  
+  **IMPORTANT**: This setting is overridden if `xml.format.splitAttributes` is set to `true`.
+* [`xml.format.preserveEmptyContent`](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Formatting.md#xmlformatpreserveemptycontent): Preserve empty content/whitespace in a tag. Default is `false`.
+* [`xml.format.preservedNewLines`](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Formatting.md#xmlformatpreservednewlines): Preserve new lines that separate tags. The value represents the maximum number of new lines per section. A value of 0 removes all new lines. Default is `2`.
+* [`xml.format.spaceBeforeEmptyCloseTag`](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Formatting.md#xmlformatspacebeforeemptyclosetag): Insert space before end of self closing tag.  
+  Example: ```<tag/> -> <tag />```. Default is `true`.
+* [`xml.format.splitAttributes`](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Formatting.md#xmlformatsplitattributes): Split multiple attributes each onto a new line. Default is `false`.
 * `xml.preferences.quoteStyle`: Preferred quote style to use for completion: `single` quotes, `double` quotes. Default is `double`.
-
-* `xml.autoCloseTags.enabled` : Enable/disable autoclosing of XML tags. Default is `true`.
-  **IMPORTANT**: Turn off `#editor.autoClosingTags#` for this to work.
-  **Note**: `editor.autoClosingBrackets` must be turned off to work.
-* `xml.codeLens.enabled`: Enable/disable XML CodeLens. Default is `false`.
-See [here](https://github.com/redhat-developer/vscode-xml/blob/master/docs/CodeLens.md) for more information.
-* `xml.preferences.showSchemaDocumentationType`: Specifies the source of the XML schema documentation displayed on hover and completion. Default is `all`.
-See [here](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Preferences.md#documentation-type) for more information.
-
-* `xml.validation.enabled`: Enable/disable all validation. Default is `true`.
-See [here](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Validation.md) for more information.
+* `xml.autoCloseTags.enabled` : Enable/disable autoclosing of XML tags. Default is `true`.  
+  **IMPORTANT**: The following settings must be turned of for this to work: `editor.autoClosingTags`, `editor.autoClosingBrackets`.
+* [`xml.codeLens.enabled`](https://github.com/redhat-developer/vscode-xml/blob/master/docs/CodeLens.md): Enable/disable XML CodeLens. Default is `false`.
+* [`xml.preferences.showSchemaDocumentationType`](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Preferences.md#documentation-type): Specifies the source of the XML schema documentation displayed on hover and completion. Default is `all`.
+* [`xml.validation.enabled`](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Validation.md): Enable/disable all validation. Default is `true`.
 * `xml.validation.schema`: Enable/disable schema based validation. Default is `true`. Ignored if `xml.validation.enabled` is set to `false`
-* `xml.validation.disallowDocTypeDecl`: Enable/disable if a fatal error is thrown if the incoming document contains a DOCTYPE declaration. Default is `false`.
-See [here](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Validation.md#disallow-doc-type-declarations) for more information.
-* `xml.validation.resolveExternalEntities`: Enable/disable resolve of external entities. Default is `false`.
-See [here](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Validation.md#resolve-external-entities) for more information.
-* `xml.validation.noGrammar`: The message severity when a document has no associated grammar. Defaults to `hint`.
-See [here](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Preferences.md#grammar) for more information.
-
-* `xml.symbols.enabled`: Enable/disable document symbols (Outline). Default is `true`.
-See [here](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Symbols.md#xmlsymbolsenabled) for more information.
+* [`xml.validation.disallowDocTypeDecl`](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Validation.md#disallow-doc-type-declarations): Enable/disable if a fatal error is thrown if the incoming document contains a DOCTYPE declaration. Default is `false`.
+* [`xml.validation.resolveExternalEntities`](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Validation.md#resolve-external-entities): Enable/disable resolve of external entities. Default is `false`.
+* [`xml.validation.noGrammar`](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Preferences.md#grammar): The message severity when a document has no associated grammar. Defaults to `hint`.
+* [`xml.symbols.enabled`](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Symbols.md#xmlsymbolsenabled): Enable/disable document symbols (Outline). Default is `true`.
 * `xml.symbols.excluded`: Disable document symbols (Outline) for the given file name patterns. Updating file name patterns does not automatically reload the Outline view for the relevant file(s). Each file must either be reopened or changed, in order to trigger an Outline view reload.
-* `xml.symbols.maxItemsComputed`: The maximum number of outline symbols and folding regions computed (limited for performance reasons). Default is `5000`.
-See [here](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Symbols.md#xmlsymbolsmaxitemscomputed) for more information.
-* `xml.symbols.showReferencedGrammars`: Show referenced grammars in the Outline. Default is `true`.
-See [here](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Symbols.md#xmlsymbolsshowreferencedgrammars) for more information.
-* `xml.symbols.filters`: Allows XML symbols filter to be associated to file name patterns.
-See [here](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Symbols.md#xmlsymbolsfilters) for more information.
+* [`xml.symbols.maxItemsComputed`](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Symbols.md#xmlsymbolsmaxitemscomputed): The maximum number of outline symbols and folding regions computed (limited for performance reasons). Default is `5000`.
+* [`xml.symbols.showReferencedGrammars`](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Symbols.md#xmlsymbolsshowreferencedgrammars): Show referenced grammars in the Outline. Default is `true`.
+* [`xml.symbols.filters`](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Symbols.md#xmlsymbolsfilters): Allows XML symbols filter to be associated to file name patterns.
 * `files.trimTrailingWhitespace`: Now affects XML formatting. Enable/disable trailing whitespace trimming when formatting an XML document. Default is `false`.
 
 ## Articles


### PR DESCRIPTION
* changed all links to be on the appropriate pref keys or text
* fixed broken line breaks (not many left)
* added some xmldoc links
* fixed image URL (because of the nature of this file being rendered from clients these need an absolute URL, as all the xmldoc links need, too)