### PR TITLE
update find-java-home version

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "fs-extra": "^8.1.0",
     "expand-home-dir": "^0.0.3",
-    "find-java-home": "0.2.0",
+    "find-java-home": "1.1.0",
     "glob": "^7.1.4",
     "path-exists": "^4.0.0",
     "vscode-languageclient": "^5.2.1"


### PR DESCRIPTION
Fixes #374.

registry logic was incorrect in old version, but fixed in new version.