### PR TITLE
Remove offline mode flag from Maven build.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,7 +11,7 @@ gulp.task('tslint', () => {
 });
 
 gulp.task('build_server', function(done) {
-	cp.execSync(mvnw()+ " -o clean verify -DskipTests", {cwd:server_dir, stdio:[0,1,2]} );
+	cp.execSync(mvnw()+ " clean verify -DskipTests", {cwd:server_dir, stdio:[0,1,2]} );
   gulp.src(server_dir +'/org.eclipse.lemminx/target/org.eclipse.lemminx-uber.jar')
 		.pipe(gulp.dest('./server'));
 	done();


### PR DESCRIPTION
- Allow users to run the build-server task, and build the language
  server even if the metadata needs to be downloaded