### PR TITLE
Disable remote repository index searcher to improve user experience.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -426,6 +426,7 @@ export function activate(context: ExtensionContext) {
     xml['xml']['format']['trimFinalNewlines'] = workspace.getConfiguration('files').get('trimFinalNewlines', true);
     xml['xml']['format']['trimTrailingWhitespace'] = workspace.getConfiguration('files').get('trimTrailingWhitespace', false);
     xml['xml']['format']['insertFinalNewline'] = workspace.getConfiguration('files').get('insertFinalNewline', false);
+    xml['xml']['maven'] = {"index": {"skip": getXMLConfiguration().get("maven.index.skip", true)}};
 
     //applying externalXmlSettings to the xmlSettings
     externalXmlSettings.xmlCatalogs.forEach(catalog => {


### PR DESCRIPTION
- Set "xml.maven.index.skip" to true by default until replaced in
  lemminx-maven with more efficient implementation.

Should help improve things in microsoft/vscode-maven/issues/47

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>