### PR TITLE
Rename telemetry events

### DIFF
--- a/USAGE_DATA.md
+++ b/USAGE_DATA.md
@@ -14,8 +14,8 @@ vscode-xml has opt-in telemetry collection, provided by [vscode-commons](https:/
     * The server version number
  * Does NOT include the `JAVA_HOME` environment variable for privacy reasons
  * The value of the `xml.server.preferBinary` setting
- * A telemetry event is sent every time the binary server download succeeds
- * A telemetry event is sent every time the binary server download fails
+ * A telemetry event is sent every time the binary server download succeeds, fails, or is stopped by the user
+    * If the download fails, the associated error is attached to the telemetry event
  * A telemetry event is sent every time you click the "Download Java" link that appears when you have [LemMinX extensions](./docs/Extensions.md) installed but don't have Java installed.
 
 ## What's included in the general telemetry data

--- a/src/server/binary/binaryServerStarter.ts
+++ b/src/server/binary/binaryServerStarter.ts
@@ -112,11 +112,20 @@ async function downloadBinary(): Promise<string> {
       });
   });
   downloadPromise.then((_binaryPath) => {
-    Telemetry.sendTelemetry(Telemetry.BINARY_DOWNLOAD_SUCCEEDED_EVT);
+    const data: any = {};
+    data[Telemetry.BINARY_DOWNLOAD_STATUS_PROP] = Telemetry.BINARY_DOWNLOAD_SUCCEEDED;
+    Telemetry.sendTelemetry(Telemetry.BINARY_DOWNLOAD_EVT, data);
   });
   downloadPromise.catch(e => {
     if (e !== ABORTED_ERROR) {
-      Telemetry.sendTelemetry(Telemetry.BINARY_DOWNLOAD_FAILED_EVT);
+      const data: any = {};
+      data[Telemetry.BINARY_DOWNLOAD_STATUS_PROP] = Telemetry.BINARY_DOWNLOAD_FAILED;
+      data['error'] = e.toString();
+      Telemetry.sendTelemetry(Telemetry.BINARY_DOWNLOAD_EVT, data);
+    } else {
+      const data: any = {};
+      data[Telemetry.BINARY_DOWNLOAD_STATUS_PROP] = Telemetry.BINARY_DOWNLOAD_ABORTED;
+      Telemetry.sendTelemetry(Telemetry.BINARY_DOWNLOAD_EVT, data);
     }
   });
   return downloadPromise;

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,14 +1,19 @@
-import { getTelemetryService, TelemetryEvent, TelemetryService } from "@redhat-developer/vscode-redhat-telemetry/lib";
+import { getTelemetryService, TelemetryService } from "@redhat-developer/vscode-redhat-telemetry/lib";
 
 /**
  * Wrap vscode-redhat-telemetry to suit vscode-xml
  */
 export namespace Telemetry {
 
-  export const OPEN_JAVA_DOWNLOAD_LINK_EVT: string = "open_java_download_link";
-  export const SETTINGS_EVT: string = "settings";
-  export const BINARY_DOWNLOAD_SUCCEEDED_EVT: string = "binary_download_succeeded";
-  export const BINARY_DOWNLOAD_FAILED_EVT: string = "binary_download_failed";
+  export const OPEN_JAVA_DOWNLOAD_LINK_EVT = "xml.open.java.download.link";
+  export const SETTINGS_EVT = "xml.settings";
+  export const BINARY_DOWNLOAD_EVT = "xml.binary.download";
+
+  export const BINARY_DOWNLOAD_STATUS_PROP = "status";
+
+  export const BINARY_DOWNLOAD_SUCCEEDED = "succeeded";
+  export const BINARY_DOWNLOAD_FAILED = "failed";
+  export const BINARY_DOWNLOAD_ABORTED = "aborted";
 
   let _telemetryManager: TelemetryService = null;
 


### PR DESCRIPTION
Use `.` consistently as the separator in event names. Prefix event names with `xml.`. Group the binary download events into `xml_binary_download`. Add a parameter `status` that indicates if the download succeeded, failed or was aborted.

Signed-off-by: David Thompson <davthomp@redhat.com>
