### PR TITLE
Do not set `files.trimTrailingWhitespace`

### DIFF
--- a/package.json
+++ b/package.json
@@ -477,13 +477,11 @@
     "configurationDefaults": {
       "[xml]": {
         "editor.autoClosingBrackets": "never",
-        "files.trimFinalNewlines": true,
-        "files.trimTrailingWhitespace": false
+        "files.trimFinalNewlines": true
       },
       "[xsl]": {
         "editor.autoClosingBrackets": "never",
-        "files.trimFinalNewlines": true,
-        "files.trimTrailingWhitespace": false
+        "files.trimFinalNewlines": true
       }
     },
     "commands": [


### PR DESCRIPTION
Do not set `files.trimTrailingWhitespace` to `false` in `package.json`,
so that it instead defaults to whatever the user sets it to.

Closes #299

Signed-off-by: David Thompson <davthomp@redhat.com>
