### PR TITLE
Revert "Update vscode-languageclient to 7.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3748,8 +3748,7 @@
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "semver-greatest-satisfied-range": {
       "version": "1.1.0",
@@ -4671,59 +4670,15 @@
     "vscode-jsonrpc": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
-      "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==",
-      "dev": true
+      "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg=="
     },
     "vscode-languageclient": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
-      "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-5.2.1.tgz",
+      "integrity": "sha512-7jrS/9WnV0ruqPamN1nE7qCxn0phkH5LjSgSp9h6qoJGoeAKzwKz/PF6M+iGA/aklx4GLZg1prddhEPQtuXI1Q==",
       "requires": {
-        "minimatch": "^3.0.4",
-        "semver": "^7.3.4",
-        "vscode-languageserver-protocol": "3.16.0"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "vscode-jsonrpc": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-          "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
-        },
-        "vscode-languageserver-protocol": {
-          "version": "3.16.0",
-          "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-          "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
-          "requires": {
-            "vscode-jsonrpc": "6.0.0",
-            "vscode-languageserver-types": "3.16.0"
-          }
-        },
-        "vscode-languageserver-types": {
-          "version": "3.16.0",
-          "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-          "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-        }
+        "semver": "^5.5.0",
+        "vscode-languageserver-protocol": "3.14.1"
       }
     },
     "vscode-languageserver": {
@@ -4740,7 +4695,6 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz",
       "integrity": "sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==",
-      "dev": true,
       "requires": {
         "vscode-jsonrpc": "^4.0.0",
         "vscode-languageserver-types": "3.14.0"
@@ -4749,8 +4703,7 @@
     "vscode-languageserver-types": {
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
-      "integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==",
-      "dev": true
+      "integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A=="
     },
     "vscode-test": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "fs-extra": "^8.1.0",
     "glob": "^7.1.4",
     "path-exists": "^4.0.0",
-    "vscode-languageclient": "^7.0.0",
+    "vscode-languageclient": "^5.2.1",
     "yauzl": "^2.10.0"
   },
   "contributes": {

--- a/src/api/xmlExtensionApiImplementation.ts
+++ b/src/api/xmlExtensionApiImplementation.ts
@@ -1,4 +1,4 @@
-import { DidChangeConfigurationNotification, LanguageClient } from "vscode-languageclient/node";
+import { DidChangeConfigurationNotification, LanguageClient } from "vscode-languageclient";
 import { ExternalXmlSettings } from "../settings/externalXmlSettings";
 import { getXMLSettings, onConfigurationChange } from "../settings/settings";
 import { RequirementsData } from "../server/requirements";

--- a/src/client/xmlClient.ts
+++ b/src/client/xmlClient.ts
@@ -1,6 +1,6 @@
 import { TelemetryEvent } from '@redhat-developer/vscode-redhat-telemetry/lib';
 import { commands, ExtensionContext, extensions, Position, TextDocument, TextEditor, Uri, window, workspace } from 'vscode';
-import { Command, ConfigurationParams, ConfigurationRequest, DidChangeConfigurationNotification, Executable, ExecuteCommandParams, LanguageClient, LanguageClientOptions, MessageType, NotificationType, RequestType, RevealOutputChannelOn, TextDocumentPositionParams } from "vscode-languageclient/node";
+import { Command, ConfigurationParams, ConfigurationRequest, DidChangeConfigurationNotification, Executable, ExecuteCommandParams, LanguageClient, LanguageClientOptions, MessageType, NotificationType, RequestType, RevealOutputChannelOn, TextDocumentPositionParams } from "vscode-languageclient";
 import { XMLFileAssociation } from '../api/xmlExtensionApi';
 import { CommandConstants } from '../commands/commandConstants';
 import { registerCommands } from '../commands/registerCommands';
@@ -14,11 +14,11 @@ import { ClientErrorHandler } from './clientErrorHandler';
 import { activateTagClosing, AutoCloseResult } from './tagClosing';
 
 namespace ExecuteClientCommandRequest {
-  export const type: RequestType<ExecuteCommandParams, any, void> = new RequestType('xml/executeClientCommand');
+  export const type: RequestType<ExecuteCommandParams, any, void, void> = new RequestType('xml/executeClientCommand');
 }
 
 namespace TagCloseRequest {
-  export const type: RequestType<TextDocumentPositionParams, AutoCloseResult, any> = new RequestType('xml/closeTag');
+  export const type: RequestType<TextDocumentPositionParams, AutoCloseResult, any, any> = new RequestType('xml/closeTag');
 }
 
 interface ActionableMessage {
@@ -29,7 +29,7 @@ interface ActionableMessage {
 }
 
 namespace ActionableNotification {
-  export const type = new NotificationType<ActionableMessage>('xml/actionableNotification');
+  export const type = new NotificationType<ActionableMessage, void>('xml/actionableNotification');
 }
 
 let languageClient: LanguageClient;

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import { commands, ExtensionContext, Position, Uri, window, workspace } from "vscode";
-import { CancellationToken, ExecuteCommandParams, ExecuteCommandRequest, LanguageClient, ReferencesRequest, TextDocumentIdentifier } from "vscode-languageclient/node";
+import { CancellationToken, ExecuteCommandParams, ExecuteCommandRequest, LanguageClient, ReferencesRequest, TextDocumentIdentifier } from "vscode-languageclient";
 import { markdownPreviewProvider } from "../markdownPreviewProvider";
 import { CommandConstants } from "./commandConstants";
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@
 import * as os from 'os';
 import * as path from 'path';
 import { ExtensionContext, extensions, languages } from "vscode";
-import { Executable, LanguageClient } from 'vscode-languageclient/node';
+import { Executable, LanguageClient } from 'vscode-languageclient';
 import { getXmlExtensionApiImplementation } from './api/xmlExtensionApiImplementation';
 import { getIndentationRules } from './client/indentation';
 import { startLanguageClient } from './client/xmlClient';

--- a/src/server/binary/binaryServerStarter.ts
+++ b/src/server/binary/binaryServerStarter.ts
@@ -6,7 +6,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { Readable } from 'stream';
 import { ExtensionContext, extensions, ProgressLocation, ProgressOptions, window, WorkspaceConfiguration } from "vscode";
-import { Executable } from "vscode-languageclient/node";
+import { Executable } from "vscode-languageclient";
 import * as yauzl from 'yauzl';
 import { getProxySettings, getProxySettingsAsEnvironmentVariables, ProxySettings } from '../../settings/proxySettings';
 import { getXMLConfiguration } from "../../settings/settings";

--- a/src/server/java/javaServerStarter.ts
+++ b/src/server/java/javaServerStarter.ts
@@ -1,7 +1,7 @@
 import * as os from 'os';
 import * as path from 'path';
 import { ExtensionContext, workspace } from 'vscode';
-import { Executable } from 'vscode-languageclient/node';
+import { Executable } from 'vscode-languageclient';
 import { RequirementsData } from '../requirements';
 import { getJavaagentFlag, getKey, getXMLConfiguration, IS_WORKSPACE_VMARGS_XML_ALLOWED, xmlServerVmargs } from '../../settings/settings';
 import { getProxySettings, getProxySettingsAsJVMArgs, ProxySettings, jvmArgsContainsProxySettings } from '../../settings/proxySettings';

--- a/src/server/serverStarter.ts
+++ b/src/server/serverStarter.ts
@@ -1,5 +1,5 @@
 import { commands, ConfigurationTarget, ExtensionContext, window } from "vscode";
-import { Executable } from "vscode-languageclient/node";
+import { Executable } from "vscode-languageclient";
 import { prepareBinaryExecutable, ABORTED_ERROR } from "./binary/binaryServerStarter";
 import { prepareJavaExecutable } from "./java/javaServerStarter";
 import { getOpenJDKDownloadLink, RequirementsData } from "./requirements";


### PR DESCRIPTION
This reverts commit c248ffb6bd51ec9b459b07e1828d0e718a2e1b02.

We need to prepare a service release (0.16.1) in order to fix the binary (see #457). The new version of the language client doesn't work with Theia, so for the purpose of the service release, we should roll back the client update.
