### PR TITLE
Use Visual Studio 2019 in NativeImage.jenkins

### DIFF
--- a/NativeImage.jenkins
+++ b/NativeImage.jenkins
@@ -69,8 +69,8 @@ pipeline {
             bat """
               pushd .
               setlocal
-              set JAVA_HOME="%cd%\\graalvm-windows-${params.GRAALVM_VERSION}\\graalvm-ce-java11-${params.GRAALVM_VERSION}"
-              call "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat" x86_amd64
+              set JAVA_HOME=%cd%\\graalvm-windows-${params.GRAALVM_VERSION}\\graalvm-ce-java11-${params.GRAALVM_VERSION}
+              call \"C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\VC\\Auxiliary\\Build\\vcvars64.bat\"
               popd
               cd lemminx
               .\\mvnw.cmd clean package -B -Dnative -DskipTests


### PR DESCRIPTION
The executable available at https://go.microsoft.com/fwlink/&LinkId=691126 no longer successfully installs the Microsoft C/C++ compiler. This means that, currently, our Windows build agents don't have the Microsoft C/C++ compiler installed. One way to overcome this obstacle is to install a newer version of the Microsoft C/C++ compiler. The newer version changes the directory structure of where things are installed. This PR changes the paths that reference the Microsoft C/C++ compiler installation so that they point to the corresponding directories for the 2019 version.

Signed-off-by: David Thompson <davthomp@redhat.com>