### PR TITLE
Added closingBracketNewLine formatting option to package.json

### DIFF
--- a/docs/Formatting.md
+++ b/docs/Formatting.md
@@ -396,3 +396,21 @@ If it is set to `true`, the above document becomes:
   </robot>
   ```
 ***
+### xml.format.closingBracketNewLine
+
+If set to `true`, the closing bracket (`>` or `/>`) of a tag with at least 2 attributes will be put on a new line.
+
+Requires [splitAttributes](#xmlformatsplitattributes) to be set to `true`.
+
+Defaults to `false`.
+
+```xml
+<a b="" c="" />
+```
+becomes
+```xml
+<a
+  b=""
+  c=""
+/>
+```

--- a/package.json
+++ b/package.json
@@ -303,6 +303,11 @@
           "default": 2,
           "markdownDescription": "How many levels to indent the attributes by when `#xml.format.splitAttributes#` is `true`. Default value is `2`. See [here](command:xml.open.docs?%5B%7B%22page%22%3A%22Formatting%22%2C%22section%22%3A%22xmlformatsplitattributesindentsize%22%7D%5D) for more information"
         },
+        "xml.format.closingBracketNewLine": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "The option to put a closing bracket on a newline when `#xml.format.splitAttributes#` is `true`. Default value is `false`. See [here](command:xml.open.docs?%5B%7B%22page%22%3A%22Formatting%22%2C%22section%22%3A%22xmlformatclosingbracketnewline%22%7D%5D) for more information."
+        },
         "xml.preferences.quoteStyle": {
           "type": "string",
           "enum": [


### PR DESCRIPTION
Added closing~~Tag~~BracketNewLine formatting option to package.json for vscode-xml setting.

Main pull request and changes on eclipse/lemminx#1051

References: #435 

Signed-off-by: Alexander Chen alchen@redhat.com