### PR TITLE
Prevent `docs/images` from being excluded from .vsix

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -9,3 +9,4 @@ CONTRIBUTING.md
 Jenkinsfile
 *.jenkins
 images/
+!docs/images


### PR DESCRIPTION
Fixes #510

Signed-off-by: David Thompson <davthomp@redhat.com>
