### PR TITLE
Fix extension not starting in vscode < 1.55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@
  * Fixed 'Go To References' in binary. See [eclipse/lemminx#1059](https://github.com/eclipse/lemminx/pull/1059).
  * CodeLens does not work in binary. See [eclipse/lemminx#1046](https://github.com/eclipse/lemminx/issues/1046).
  * Error while saving file to cache on Windows OS (PosixFileAttributeView not supported). See [eclipse/lemminx#734](https://github.com/eclipse/lemminx/issues/734).
-
+ * Extension doesn't start when running in vscode < 1.55. See [#520](https://github.com/redhat-developer/vscode-xml/pull/520).
+ 
 ## [0.16.1](https://github.com/redhat-developer/vscode-xml/milestone/20?closed=1) (May 18, 2021)
 
 ### Enhancements

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,9 +37,9 @@
       "dev": true
     },
     "@redhat-developer/vscode-redhat-telemetry": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@redhat-developer/vscode-redhat-telemetry/-/vscode-redhat-telemetry-0.1.1.tgz",
-      "integrity": "sha512-uMJNiFNUXCYy/4KZaX+Ctueq+KXIWyS5Cfv2wqHNNzpV9+EhPLHUJoZKbCMY/P+IlgqTWYfpDkghZHiq5ChvEA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@redhat-developer/vscode-redhat-telemetry/-/vscode-redhat-telemetry-0.2.0.tgz",
+      "integrity": "sha512-qS9p+iXpdMwCzhVRr/Ft5dMQQXB+6CxBRnpp3NDUuxYP1s/K/B1dPlIW5lKncjPUwYaKvPbpMgGGDmsosOzT8A==",
       "requires": {
         "@types/analytics-node": "^3.1.4",
         "analytics-node": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "webpack-cli": "^4.6.0"
   },
   "dependencies": {
-    "@redhat-developer/vscode-redhat-telemetry": "0.1.1",
+    "@redhat-developer/vscode-redhat-telemetry": "0.2.0",
     "expand-home-dir": "^0.0.3",
     "find-java-home": "1.1.0",
     "fs-extra": "^8.1.0",


### PR DESCRIPTION
Update vscode-redhat-telenetry to 0.2.0, to fix

```
Activating extension 'redhat.vscode-xml' failed: Cannot read property 'id' of undefined.
```

This affects vscode API < 1.55 (Che/Theia are at 1.50)