### PR TITLE
Document auto tag renaming in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@ This VS Code extension provides support for creating and editing XML documents, 
 
   * Syntax error reporting
   * General code completion
-  * [Auto-close tags](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Features.md#xml-tag-auto-close)
+  * [Auto-close tags](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Features/XMLFeatures.md#xml-tag-auto-close)
   * Automatic node indentation
   * Symbol highlighting
   * Document folding
   * Document links
   * [Document symbols and outline](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Symbols.md)
-  * [Renaming support](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Features.md#rename-tag)
+  * [Renaming support](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Features/XMLFeatures.md#rename-tag)
+  * [Automatic Tag Renaming](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Features/XMLFeatures.md#auto-rename-tag)
   * [Document Formatting](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Formatting.md)
   * [DTD validation](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Validation.md#validation-with-dtd-grammar)
   * DTD completion

--- a/docs/Features/XMLFeatures.md
+++ b/docs/Features/XMLFeatures.md
@@ -14,7 +14,18 @@ Using `/` in an opening tag will auto close the tag.
 
 Linked editing is supported, allowing for simultaneous changes an opening and closing tag pair.
 
-To enable this feature, the setting `editor.linkedEditing` must be set to `true` in the `settings.json.
+This feature is enabled by default for XML and XSL files.
+
+If you would like to disable it, add the following to your `settings.json`:
+
+```json
+"[xml]" : {
+  "editor.linkedEditing": false
+},
+"[xsl]" : {
+  "editor.linkedEditing": false
+}
+```
 
 ![Linked Editing](../images/Features/LinkedEditingXML.gif)
 

--- a/package.json
+++ b/package.json
@@ -502,10 +502,12 @@
     "configurationDefaults": {
       "[xml]": {
         "editor.autoClosingBrackets": "never",
+        "editor.linkedEditing": true,
         "files.trimFinalNewlines": true
       },
       "[xsl]": {
         "editor.autoClosingBrackets": "never",
+        "editor.linkedEditing": true,
         "files.trimFinalNewlines": true
       }
     },


### PR DESCRIPTION
Add a quick explanation on how to enable it. Fix link that explains the old method of tag renaming.

Signed-off-by: David Thompson <davthomp@redhat.com>
