### PR TITLE
Linked editing no longer enabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ This VS Code extension provides support for creating and editing XML documents, 
 
 ## Features
 
+| Regular font       | *Italics* font                              |
+| ------------------ | ------------------------------------------- |
+| enabled by default | requires additional configuration to enable |
+
   * Syntax error reporting
   * General code completion
   * [Auto-close tags](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Features/XMLFeatures.md#xml-tag-auto-close)
@@ -21,7 +25,7 @@ This VS Code extension provides support for creating and editing XML documents, 
   * Document links
   * [Document symbols and outline](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Symbols.md)
   * [Renaming support](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Features/XMLFeatures.md#rename-tag)
-  * [Automatic Tag Renaming](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Features/XMLFeatures.md#auto-rename-tag)
+  * *[Automatic Tag Renaming](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Features/XMLFeatures.md#auto-rename-tag) when `editor.linkedEditing` is enabled*
   * [Document Formatting](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Formatting.md)
   * [DTD validation](https://github.com/redhat-developer/vscode-xml/blob/master/docs/Validation.md#validation-with-dtd-grammar)
   * DTD completion

--- a/docs/Features/XMLFeatures.md
+++ b/docs/Features/XMLFeatures.md
@@ -14,18 +14,7 @@ Using `/` in an opening tag will auto close the tag.
 
 Linked editing is supported, allowing for simultaneous changes an opening and closing tag pair.
 
-This feature is enabled by default for XML and XSL files.
-
-If you would like to disable it, add the following to your `settings.json`:
-
-```json
-"[xml]" : {
-  "editor.linkedEditing": false
-},
-"[xsl]" : {
-  "editor.linkedEditing": false
-}
-```
+To enable this feature, the setting `editor.linkedEditing` must be set to `true` in your `settings.json`.
 
 ![Linked Editing](../images/Features/LinkedEditingXML.gif)
 

--- a/package.json
+++ b/package.json
@@ -502,12 +502,10 @@
     "configurationDefaults": {
       "[xml]": {
         "editor.autoClosingBrackets": "never",
-        "editor.linkedEditing": true,
         "files.trimFinalNewlines": true
       },
       "[xsl]": {
         "editor.autoClosingBrackets": "never",
-        "editor.linkedEditing": true,
         "files.trimFinalNewlines": true
       }
     },


### PR DESCRIPTION
Document that its not enabled by default. Explain how to enable it in the documentation.

Signed-off-by: David Thompson <davthomp@redhat.com>
