### PR TITLE
Stop the language server using a disposable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
  * CodeLens does not work in binary. See [eclipse/lemminx#1046](https://github.com/eclipse/lemminx/issues/1046).
  * Error while saving file to cache on Windows OS (PosixFileAttributeView not supported). See [eclipse/lemminx#734](https://github.com/eclipse/lemminx/issues/734).
  * Extension doesn't start when running in vscode < 1.55. See [#520](https://github.com/redhat-developer/vscode-xml/pull/520).
+  * Stop the language server using a disposable to prevent it from running after VS Code exits. See [#TODO](https://github.com/redhat-developer/vscode-xml/pull/TODO).
 
 ## [0.16.1](https://github.com/redhat-developer/vscode-xml/milestone/20?closed=1) (May 18, 2021)
 

--- a/src/client/xmlClient.ts
+++ b/src/client/xmlClient.ts
@@ -44,7 +44,7 @@ export async function startLanguageClient(context: ExtensionContext, executable:
     return Telemetry.sendTelemetry(e.name, e.properties);
   });
 
-  context.subscriptions.push(languageClient.start());
+  languageClient.start()
   await languageClient.onReady();
 
   // ---

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,8 +26,6 @@ import { getXMLConfiguration } from './settings/settings';
 import { Telemetry } from './telemetry';
 import { registerClientOnlyCommands } from './commands/registerCommands';
 
-let languageClient: LanguageClient;
-
 export async function activate(context: ExtensionContext): Promise<XMLExtensionApi> {
 
   await Telemetry.startTelemetry(context);
@@ -58,13 +56,12 @@ export async function activate(context: ExtensionContext): Promise<XMLExtensionA
   const serverOptions: Executable = await prepareExecutable(
     requirementsData, collectXmlJavaExtensions(extensions.all, getXMLConfiguration().get("extension.jars", [])), context);
 
-  languageClient = await startLanguageClient(context, serverOptions, logfile, externalXmlSettings, requirementsData);
+  const languageClient = await startLanguageClient(context, serverOptions, logfile, externalXmlSettings, requirementsData);
+  context.subscriptions.push({
+    dispose: async (): Promise<void> => {
+      await languageClient.stop();
+    }
+  });
 
   return getXmlExtensionApiImplementation(languageClient, logfile, externalXmlSettings, requirementsData);
-}
-
-export async function deactivate(): Promise<void> {
-  if (languageClient) {
-    await languageClient.stop();
-  }
 }


### PR DESCRIPTION
This should prevent the langauge server from running after VS Code has stopped.

Signed-off-by: David Thompson <davthomp@redhat.com>
