### PR TITLE
Support `shouldLanguageServerExitOnShutdown` capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
  * CodeLens does not work in binary. See [eclipse/lemminx#1046](https://github.com/eclipse/lemminx/issues/1046).
  * Error while saving file to cache on Windows OS (PosixFileAttributeView not supported). See [eclipse/lemminx#734](https://github.com/eclipse/lemminx/issues/734).
  * Extension doesn't start when running in vscode < 1.55. See [#520](https://github.com/redhat-developer/vscode-xml/pull/520).
+ * Language server remains running after VS Code stops. See [#530](https://github.com/redhat-developer/vscode-xml/pull/530).
 
 ## [0.16.1](https://github.com/redhat-developer/vscode-xml/milestone/20?closed=1) (May 18, 2021)
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dtd"
   ],
   "xmlServer": {
-    "version": "0.17.0"
+    "version": "0.17.1"
   },
   "binaryServerDownloadUrl": {
     "linux": "https://download.jboss.org/jbosstools/vscode/snapshots/lemminx-binary/LATEST/lemminx-linux.zip",

--- a/src/client/xmlClient.ts
+++ b/src/client/xmlClient.ts
@@ -129,7 +129,8 @@ function getLanguageClientOptions(logfile: string, externalXmlSettings: External
           }
         },
         actionableNotificationSupport: true,
-        openSettingsCommandSupport: true
+        openSettingsCommandSupport: true,
+        shouldLanguageServerExitOnShutdown: true
       }
     },
     errorHandler: new ClientErrorHandler('XML'),


### PR DESCRIPTION
Supports the capability, which means that language server shuts down when `shutdown` is received instead of when `exit` is received.

See eclipse/lemminx#1070

Signed-off-by: David Thompson <davthomp@redhat.com>
