### PR TITLE
Added `xml.restart.language.server` command for language server connection restart

### DIFF
--- a/package.json
+++ b/package.json
@@ -613,6 +613,11 @@
         "command": "xml.command.bind.grammar",
         "title": "Bind to grammar/schema file",
         "category": "XML"
+      },
+      {
+        "command": "xml.restart.language.server",
+        "title": "Restart Language Server",
+        "category": "XML"
       }
     ],
     "menus": {

--- a/src/commands/commandConstants.ts
+++ b/src/commands/commandConstants.ts
@@ -74,6 +74,11 @@ export namespace ClientCommandConstants {
    * Client command to execute an XML command on XML Language Server side.
    */
   export const EXECUTE_WORKSPACE_COMMAND = 'xml.workspace.executeCommand';
+
+  /**
+   * Command to restart connection to language server.
+   */
+  export const RESTART_LANGUAGE_SERVER = 'xml.restart.language.server';
 }
 
 /**

--- a/src/server/java/javaServerStarter.ts
+++ b/src/server/java/javaServerStarter.ts
@@ -10,7 +10,7 @@ import glob = require('glob');
 
 declare var v8debug;
 
-const DEBUG = (typeof v8debug === 'object') || startedInDebugMode();
+export const DEBUG = (typeof v8debug === 'object') || startedInDebugMode();
 
 export async function prepareJavaExecutable(
   context: ExtensionContext,


### PR DESCRIPTION
Added `xml.restart.language.server` command to trigger language server connection restart.
![Peek 2022-07-20 13-16](https://user-images.githubusercontent.com/26389510/180043487-2d3ba6b7-5f1e-4d1b-b466-927b284aa470.gif)



Closes #539 

Signed-off-by: Alexander Chen alchen@redhat.com