### PR TITLE
set bindingWizardSupport for client support

### DIFF
--- a/src/client/xmlClient.ts
+++ b/src/client/xmlClient.ts
@@ -130,6 +130,7 @@ function getLanguageClientOptions(logfile: string, externalXmlSettings: External
         },
         actionableNotificationSupport: true,
         openSettingsCommandSupport: true,
+        bindingWizardSupport: true,
         shouldLanguageServerExitOnShutdown: true
       }
     },


### PR DESCRIPTION
Set `bindingWizardSupport` in client to enable `lemminx` support of "Open Binding Wizard" CodeAction.

References #515 and eclipse/lemminx/pull/1088

Signed-off-by: Alexander Chen alchen@redhat.com