### PR TITLE
Validate the file assocation pattern in the wizard

### DIFF
--- a/src/commands/commandConstants.ts
+++ b/src/commands/commandConstants.ts
@@ -102,4 +102,9 @@ export namespace ServerCommandConstants {
    * Command to check if the current XML document is bound to a grammar
    */
   export const CHECK_BOUND_GRAMMAR = "xml.check.bound.grammar"
+
+  /**
+   * Command to check if a given file pattern matches any file on the workspace
+   */
+  export const CHECK_FILE_PATTERN = "xml.check.file.pattern"
 }

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -216,7 +216,16 @@ async function bindWithFileAssociation(documentURI: Uri, grammarURI: Uri, docume
     title: "File Association Pattern",
     value: defaultPattern,
     placeHolder: defaultPattern,
-    prompt: "Enter the pattern of the XML document(s) to be bound."
+    prompt: "Enter the pattern of the XML document(s) to be bound.",
+    validateInput: async (pattern: string) => {
+      let hasMatch = false;
+      try {
+        hasMatch = await commands.executeCommand(ClientCommandConstants.EXECUTE_WORKSPACE_COMMAND, ServerCommandConstants.CHECK_FILE_PATTERN, pattern, documentURI.toString());
+      } catch (error) {
+        console.log(`Error while validating file pattern : ${error}`);
+      }
+      return !hasMatch ? "The pattern will not match any file." : null
+    }
   }
   const inputPattern = (await window.showInputBox(inputBoxOptions));
   if (!inputPattern) {


### PR DESCRIPTION
- Fixes #586
- Declare command "xml.check.file.pattern" to be used on the server side
  to determine if a given pattern will match any files

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

This will require https://github.com/eclipse/lemminx/pull/1112 .