### PR TITLE
Update to find-java-home 1.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1782,9 +1782,9 @@
       }
     },
     "find-java-home": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/find-java-home/-/find-java-home-1.1.0.tgz",
-      "integrity": "sha512-bSTCKNZ193UM/+ZZoNDzICAEHcVywovkhsWCkZALjCvRXQ+zXTe/XATrrP4CpxkaP6YFhQJOpyRpH0P2U/woDA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/find-java-home/-/find-java-home-1.2.2.tgz",
+      "integrity": "sha512-rN2LcQa+YDwfnPT0TQgn015eYqJkn3h3G/uVX5oOD2Ge7gKOuoJrntAJO4BiGb+K6lo6Mb+xJdoqbfzqaC75gw==",
       "requires": {
         "which": "~1.0.5",
         "winreg": "~1.2.2"

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   "dependencies": {
     "@redhat-developer/vscode-redhat-telemetry": "0.4.2",
     "expand-home-dir": "^0.0.3",
-    "find-java-home": "1.1.0",
+    "find-java-home": "1.2.2",
     "fs-extra": "^8.1.0",
     "glob": "^7.1.4",
     "path-exists": "^4.0.0",


### PR DESCRIPTION
- Fixes #601
- Update find-java-home to benefit from fix that correctly resolves
  relative symbolic links

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>