### PR TITLE
Build the LemMinX binary as a "mostly static" native image

### DIFF
--- a/NativeImage.jenkins
+++ b/NativeImage.jenkins
@@ -27,7 +27,7 @@ pipeline {
                 sh "git clone https://github.com/eclipse/lemminx.git"
               }
             }
-            sh "cd lemminx && JAVA_HOME=\$GRAALVM_PATH ./mvnw clean package -B -Dnative -DskipTests -Dgraalvm.static=--static && cd .."
+            sh "cd lemminx && JAVA_HOME=\$GRAALVM_PATH ./mvnw clean package -B -Dnative -DskipTests -Dgraalvm.static='--static -H:+StaticExecutableWithDynamicLibC' && cd .."
             sh "cp lemminx/org.eclipse.lemminx/target/lemminx-linux* lemminx-linux"
             stash name: 'lemminx-linux', includes: 'lemminx-linux'
           }


### PR DESCRIPTION
- Fixes #597
- Use -H:+StaticExecutableWithDynamicLibC to statically link everything
  except libc

See https://www.graalvm.org/reference-manual/native-image/StaticImages/#build-mostly-static-native-image for more details on the flag.

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>