### PR TITLE
Use vsce 1.x since 2.x is not compatible with Node 12.x

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ def installBuildRequirements(){
 	def nodeHome = tool 'nodejs-12.13.1'
 	env.PATH="${env.PATH}:${nodeHome}/bin"
 	sh "npm install -g typescript"
-	sh "npm install -g vsce"
+	sh 'npm install -g "vsce@<2"'
 }
 
 def buildVscodeExtension(){


### PR DESCRIPTION
```
+npm WARN notsup Unsupported engine for vsce@2.1.0: wanted: {"node":">= 14"} (current: {"node":"12.13.1","npm":"6.12.1"})
+npm WARN notsup Not compatible with your version of node/npm: vsce@2.1.0
+
++ vsce@2.1.0
```


Signed-off-by: Roland Grunberg <rgrunber@redhat.com>