### PR TITLE
Use curl instead of wget to be consistent with usage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,9 +59,9 @@ node('rhel8'){
 
 	stage 'package binary hashes'
 	sh "mkdir ./server"
-	sh "wget ${downloadLocation}/vscode/${binaryUploadFolder}/lemminx-binary/${packageJson.version}-${env.BUILD_NUMBER}/lemminx-linux.sha256 -O ./server/lemminx-linux.sha256"
-	sh "wget ${downloadLocation}/vscode/${binaryUploadFolder}/lemminx-binary/${packageJson.version}-${env.BUILD_NUMBER}/lemminx-win32.sha256 -O ./server/lemminx-win32.sha256"
-	sh "wget ${downloadLocation}/vscode/${binaryUploadFolder}/lemminx-binary/${packageJson.version}-${env.BUILD_NUMBER}/lemminx-osx-x86_64.sha256 -O ./server/lemminx-osx-x86_64.sha256"
+	sh "curl ${downloadLocation}/vscode/${binaryUploadFolder}/lemminx-binary/${packageJson.version}-${env.BUILD_NUMBER}/lemminx-linux.sha256 -o ./server/lemminx-linux.sha256"
+	sh "curl ${downloadLocation}/vscode/${binaryUploadFolder}/lemminx-binary/${packageJson.version}-${env.BUILD_NUMBER}/lemminx-win32.sha256 -o ./server/lemminx-win32.sha256"
+	sh "curl ${downloadLocation}/vscode/${binaryUploadFolder}/lemminx-binary/${packageJson.version}-${env.BUILD_NUMBER}/lemminx-osx-x86_64.sha256 -o ./server/lemminx-osx-x86_64.sha256"
 
 	stage 'install vscode-xml build requirements'
 	installBuildRequirements()


### PR DESCRIPTION
- Also on certain machines, wget (without --inet4-only) can fail with
  default options

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

Sample of the possible failure :

```
12:38:21  + wget https://download.jboss.org/jbosstools/vscode/snapshots/lemminx-binary/0.18.3-482/lemminx-linux.sha256 -O ./server/lemminx-linux.sha256
12:38:21  --2022-01-25 12:38:20--  https://download.jboss.org/jbosstools/vscode/snapshots/lemminx-binary/0.18.3-482/lemminx-linux.sha256
12:38:21  Resolving download.jboss.org (download.jboss.org)... ${some_ipv6_addr}, ${some_ipv6_addr}, ${some_ipv4_addr}, ...
12:38:24  Connecting to download.jboss.org (download.jboss.org)|${some_ipv6_addr}|:443... failed: No route to host.
12:38:27  Connecting to download.jboss.org (download.jboss.org)|${some_ipv6_addr}|:443... failed: No route to host.
12:38:27  Connecting to download.jboss.org (download.jboss.org)|${some_ipv4_addr}|:443... connected.
12:38:27  HTTP request sent, awaiting response... 404 Not Found
12:38:27  2022-01-25 12:38:26 ERROR 404: Not Found.
```