### PR TITLE
Use LemMinX 0.18.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dtd"
   ],
   "xmlServer": {
-    "version": "0.18.2"
+    "version": "0.18.3"
   },
   "binaryServerDownloadUrl": {
     "linux": "https://download.jboss.org/jbosstools/vscode/snapshots/lemminx-binary/LATEST/lemminx-linux.zip",


### PR DESCRIPTION
Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

CC @angelozerr . We need this just prior to building to use the released LS.