### PR TITLE
Eliminate need for downloading just-released binary checksums.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,9 +59,8 @@ node('rhel8'){
 
 	stage 'package binary hashes'
 	sh "mkdir ./server"
-	sh "curl ${downloadLocation}/vscode/${binaryUploadFolder}/lemminx-binary/${packageJson.version}-${env.BUILD_NUMBER}/lemminx-linux.sha256 -o ./server/lemminx-linux.sha256"
-	sh "curl ${downloadLocation}/vscode/${binaryUploadFolder}/lemminx-binary/${packageJson.version}-${env.BUILD_NUMBER}/lemminx-win32.sha256 -o ./server/lemminx-win32.sha256"
-	sh "curl ${downloadLocation}/vscode/${binaryUploadFolder}/lemminx-binary/${packageJson.version}-${env.BUILD_NUMBER}/lemminx-osx-x86_64.sha256 -o ./server/lemminx-osx-x86_64.sha256"
+	unstash name: 'checksums'
+	sh "mv lemminx-*.sha256 ./server"
 
 	stage 'install vscode-xml build requirements'
 	installBuildRequirements()
@@ -101,7 +100,7 @@ node('rhel8'){
 		}
 
 		// Open-vsx Marketplace
-		sh "npm install -g ovsx"
+		sh 'npm install -g "ovsx<0.3.0"'
 		withCredentials([[$class: 'StringBinding', credentialsId: 'open-vsx-access-token', variable: 'OVSX_TOKEN']]) {
 			sh 'ovsx publish -p ${OVSX_TOKEN}' + " ${vsix[0].path}"
 		}

--- a/NativeImage.jenkins
+++ b/NativeImage.jenkins
@@ -130,6 +130,7 @@ pipeline {
         sh "sha256sum lemminx-linux > lemminx-linux.sha256"
         sh "sha256sum lemminx-win32.exe > lemminx-win32.sha256"
         sh "sha256sum lemminx-osx-x86_64 > lemminx-osx-x86_64.sha256"
+        stash name: 'checksums', includes: 'lemminx-*.sha256'
 
         // Move artifacts into a folder name unique to this build
         sh "curl -Lo package.json https://raw.githubusercontent.com/${params.FORK}/vscode-xml/${params.BRANCH}/package.json"


### PR DESCRIPTION
- When the build process finishes building binaries, and generating the
  checksums, we should stash these to avoid having to download once
  deployed
- Also use ovsx<0.3.0 to ensure we build with Node v12

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>