### PR TITLE
Upversion to 0.19.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-xml",
-  "version": "0.18.4",
+  "version": "0.19.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-xml",
   "displayName": "XML",
   "description": "XML Language Support by Red Hat",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "author": "Red Hat",
   "publisher": "redhat",
   "icon": "icons/icon128.png",


### PR DESCRIPTION
Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

@angelozerr In the future, don't forget that the `package-lock.json` also needs to be updated. This didn't affect the release as `0.19.0` was set everywhere, but good to update it for consistency.