### PR TITLE
Upversion to 0.21.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-xml",
-  "version": "0.19.2",
+  "version": "0.21.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-xml",
   "displayName": "XML",
   "description": "XML Language Support by Red Hat",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "author": "Red Hat",
   "publisher": "redhat",
   "icon": "icons/icon128.png",


### PR DESCRIPTION
Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

@angelozerr , we missed `package-lock.json` again, but I don't think it affects the release. Still, we should try to bump this correctly next time.