### PR TITLE
Remove rsync calls from Jenkins script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,7 +104,6 @@ node('rhel8'){
 		withCredentials([[$class: 'StringBinding', credentialsId: 'open-vsx-access-token', variable: 'OVSX_TOKEN']]) {
 			sh 'ovsx publish -p ${OVSX_TOKEN}' + " ${vsix[0].path}"
 		}
-		archive includes:"**.vsix"
 
 		stage "Upload to /vscode-xml/stable"
 		// copy this stable build to Akamai-mirrored /static/ URL, so staging can be cleaned out more easily

--- a/NativeImage.jenkins
+++ b/NativeImage.jenkins
@@ -133,24 +133,7 @@ pipeline {
         sh "sha256sum lemminx-win32.exe > lemminx-win32.sha256"
         sh "sha256sum lemminx-osx-x86_64 > lemminx-osx-x86_64.sha256"
         stash name: 'checksums', includes: 'lemminx-*.sha256'
-
-        // Move artifacts into a folder name unique to this build
-        sh "curl -Lo package.json https://raw.githubusercontent.com/${params.FORK}/vscode-xml/${params.BRANCH}/package.json"
-        script {
-          def packageJson = readJSON file: 'package.json'
-          def vscodeXmlVersion = packageJson?.version
-          def uploadFolderName = 'snapshots'
-          if (publishToMarketPlace.equals('true')) {
-            uploadFolderName = 'stable'
-          }
-          if (!publishToMarketPlace.equals('true')){
-            sh """
-              ln  --symbolic ${vscodeXmlVersion}-${env.BUILD_NUMBER} LATEST
-              rsync -Pzrlt --rsh=ssh --protocol=28 LATEST ${params.UPLOAD_LOCATION}/vscode/snapshots/lemminx-binary
-            """
-          }
-		  stash name: 'binaries', includes: 'lemminx-*.zip'
-        }
+        stash name: 'binaries', includes: 'lemminx-*.zip'
       }
     }
   }


### PR DESCRIPTION
- In preparation for deploying to GitHub Releases, remove functionality
  that uploaded to download.jboss
- Remove unnecessary 'archive' step near end of script

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>