### PR TITLE
Create an entry under GH Releases for native build artifacts.

### DIFF
--- a/.github/workflows/native-image.yaml
+++ b/.github/workflows/native-image.yaml
@@ -1,0 +1,109 @@
+  name: native-image
+  on:
+    schedule:
+      - cron: '0 8 * * *'
+  jobs:
+    build-binary-unix:
+      runs-on: ${{ matrix.os }}
+      env:
+        GRAALVM_VERSION: 22.0.0.2
+        GRAALVM_JAVA: java17
+      strategy:
+        fail-fast: true
+        matrix:
+          os: [macos-latest, ubuntu-latest]
+          include:
+            - os: macos-latest
+              label: 'darwin'
+            - os: ubuntu-latest
+              label: 'linux'
+      steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: 'eclipse/lemminx'
+      - name: Cache Maven dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.m2/wrapper
+            !~/.m2/repository/org/eclipse/lemminx
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Cache GraalVM
+        uses: actions/cache@v2
+        with:
+          path: |
+            /opt/hostedtoolcache/GraalVM
+            ~/hostedtoolcache/GraalVM
+          key: ${{ runner.os }}-graalvm-${{env.GRAALVM_VERSION}}
+          restore-keys: |
+            ${{ runner.os }}-graalvm-
+      - uses: DeLaGuardo/setup-graalvm@5.0
+        with:
+          graalvm: ${{env.GRAALVM_VERSION}}
+          java: ${{env.GRAALVM_JAVA}}
+      - run: ./mvnw -B package -Dnative -DskipTests $([ $(uname -s) = Linux ] && echo "-Dgraalvm.static=-H:+StaticExecutableWithDynamicLibC") -Dcbi.jarsigner.skip=true
+      - run: rm org.eclipse.lemminx/target/*.build_artifacts.txt
+      - run: mv org.eclipse.lemminx/target/lemminx-* lemminx-${{ matrix.label }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: lemminx-${{ matrix.label }}
+          path: lemminx-${{ matrix.label }}
+          if-no-files-found: error
+    build-binary-windows:
+      runs-on: windows-latest
+      env:
+        GRAALVM_VERSION: 22.0.0.2
+        GRAALVM_JAVA: java17
+      steps:
+      - name: Check out LemMinX
+        uses: actions/checkout@v2
+        with:
+          repository: 'eclipse/lemminx'
+      - name: Cache Maven dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.m2/wrapper
+            !~/.m2/repository/org/eclipse/lemminx
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Cache GraalVM
+        uses: actions/cache@v2
+        with:
+          path: |
+            C:\hostedtoolcache\windows\GraalVM
+          key: ${{ runner.os }}-graalvm-${{env.GRAALVM_VERSION}}
+          restore-keys: |
+            ${{ runner.os }}-graalvm-
+      - uses: ilammy/msvc-dev-cmd@v1.10.0
+      - uses: DeLaGuardo/setup-graalvm@5.0
+        with:
+          graalvm: ${{env.GRAALVM_VERSION}}
+          java: ${{env.GRAALVM_JAVA}}
+      - run: .\mvnw.cmd -B package -Dnative -DskipTests -D "cbi.jarsigner.skip=true"
+      - run: mv org.eclipse.lemminx\target\lemminx-*.exe lemminx-win32.exe
+      - uses: actions/upload-artifact@v2
+        with:
+          name: lemminx-win32
+          path: lemminx-win32.exe
+          if-no-files-found: error
+    release-binary-artifacts:
+      needs: [build-binary-unix, build-binary-windows]
+      runs-on: ubuntu-latest
+      steps:
+      - uses: actions/download-artifact@v3
+      - run: for f in lemminx-linux lemminx-darwin lemminx-win32; do pushd ${f} && chmod u+x ${f}* && zip ../${f}.zip ${f}* && sha256sum ${f}* > ../${f}.sha256 && popd; done
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest"
+          prerelease: true
+          title: "Development Build"
+          files: |
+            lemminx-*.zip
+            lemminx-*.sha256


### PR DESCRIPTION
- Copy over existing LemMinX native image build from eclipse/lemminx
- Use actions/download-artifact no-args to fetch all uploaded artifacts
  into their own folder
- Use 'marvinpinto/action-automatic-releases' to deploy to Releases
  - Create a tag "latest" marked as pre-release and attach latest zipped
    binary artifacts
- Scheduled daily

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

This is basically all the work done on https://github.com/eclipse/lemminx/pull/1184