### PR TITLE
Add usesOnlineServices tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
           "markdownDescription": "Enable usage data and errors to be sent to Red Hat servers. Read our [privacy statement](https://developers.redhat.com/article/tool-data-collection).",
           "scope": "window",
           "tags": [
+            "usesOnlineServices",
             "telemetry"
           ]
         },


### PR DESCRIPTION
By adding the `usesOnlineServices` tag to the telemetry setting, users can find the setting more easily by clicking on the ellipses and selecting "Show settings for online services" while in the Settings editor.


![A screenshot showing a button that users can use to apply the usesOnlineServices tag to the Settings editor search widget query](https://user-images.githubusercontent.com/7199958/163849593-d6d32bd4-48f2-4952-924d-3ea0a42b362b.PNG)
