### PR TITLE
Add LemMinX binary artifacts to release tab only on new changes.

### DIFF
--- a/.github/workflows/native-image.yaml
+++ b/.github/workflows/native-image.yaml
@@ -96,9 +96,26 @@
       needs: [build-binary-unix, build-binary-windows]
       runs-on: ubuntu-latest
       steps:
-      - uses: actions/download-artifact@v3
-      - run: for f in lemminx-linux lemminx-darwin lemminx-win32; do pushd ${f} && chmod u+x ${f}* && zip ../${f}.zip ${f}* && sha256sum ${f}* > ../${f}.sha256 && popd; done
-      - uses: "marvinpinto/action-automatic-releases@latest"
+      - uses: actions/checkout@v2
+        with:
+          repository: 'eclipse/lemminx'
+          fetch-depth: 2
+      - run: git rev-parse HEAD^ > lastCommit
+      - name: Check New Changes To LS
+        id: cache-last-commit
+        uses: actions/cache@v2
+        with:
+          path: lastCommit
+          key: lastCommit-${{ hashFiles('lastCommit') }}
+      - name: Retrieve Binary Artifacts
+        if: steps.cache-last-commit.outputs.cache-hit != 'true'
+        uses: actions/download-artifact@v3
+      - name: Prepare Binary Artifacts
+        if: steps.cache-last-commit.outputs.cache-hit != 'true'
+        run: for f in lemminx-linux lemminx-darwin lemminx-win32; do pushd ${f} && chmod u+x ${f}* && zip ../${f}.zip ${f}* && sha256sum ${f}* > ../${f}.sha256 && popd; done
+      - name: Release Binary Artifacts
+        if: steps.cache-last-commit.outputs.cache-hit != 'true'
+        uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "latest"


### PR DESCRIPTION
- Save the last commit from LemMinX in a file (lastCommit)
- Use the GH cache action to cache the file
- If a cache hit occurs, then the commit has been built, otherwise it is
  a new commit and should result in releasing the binary artifacts

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>