### PR TITLE
Replace obsolete AdoptOpenJDK link with Adoptium

### DIFF
--- a/src/server/requirements.ts
+++ b/src/server/requirements.ts
@@ -191,7 +191,7 @@ function openJDKDownload(reject, cause: string) {
 export function getOpenJDKDownloadLink(): Uri {
   let jdkUrl = 'https://developers.redhat.com/products/openjdk/download/?sc_cid=701f2000000RWTnAAO';
   if (process.platform === 'darwin') {
-    jdkUrl = 'https://adoptopenjdk.net/releases.html';
+    jdkUrl = 'https://adoptium.net/temurin/releases';
   }
   return Uri.parse(jdkUrl);
 }


### PR DESCRIPTION
In 2021, [AdoptOpenJDK has become Adoptium](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).

The old site does point to the new site but that requires several additional clicks to get there. Besides, the [old download site](https://adoptopenjdk.net/releases.html) is no longer being updated, and fails to mention JDK 17.

See also #270.
