### PR TITLE
Add support for pre-releases.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,6 +34,22 @@ gulp.task('build_server_with_binary', function(done) {
 	done();
 });
 
+gulp.task('prepare_pre_release', function(done) {
+    const json = JSON.parse(fse.readFileSync("./package.json").toString());
+    const stableVersion = json.version.match(/(\d+)\.(\d+)\.(\d+)/);
+    const major = stableVersion[1];
+    const minor = stableVersion[2];
+    const date = new Date();
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+    const hours = date.getHours();
+    const patch = `${date.getFullYear()}${prependZero(month)}${prependZero(day)}${prependZero(hours)}`;
+    const insiderPackageJson = Object.assign(json, {
+        version: `${major}.${minor}.${patch}`,
+    });
+    fse.writeFileSync("./package.json", JSON.stringify(insiderPackageJson, null, 2));
+    done();
+});
 
 function isWin() {
 	return /^win/.test(process.platform);
@@ -49,4 +65,11 @@ function isLinux() {
 
 function mvnw() {
 	return isWin()? "mvnw.cmd": server_dir+"/mvnw";
+}
+
+function prependZero(number) {
+    if (number > 99) {
+        throw "Unexpected value to prepend with zero";
+    }
+    return `${number < 10 ? "0" : ""}${number}`;
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     }
   },
   "engines": {
-    "vscode": "^1.61.0"
+    "vscode": "^1.63.0"
   },
   "activationEvents": [
     "onLanguage:xml",


### PR DESCRIPTION
- VS Code Engine to 1.63.0
- Upgrade build jobs to use NodeJS 14
- Add prepare_pre_release gulp task

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>