### PR TITLE
Fix release tab loaction for MacOS LemMinX binary artifact.

### DIFF
--- a/.github/workflows/native-image.yaml
+++ b/.github/workflows/native-image.yaml
@@ -112,7 +112,7 @@
         uses: actions/download-artifact@v3
       - name: Prepare Binary Artifacts
         if: steps.cache-last-commit.outputs.cache-hit != 'true'
-        run: for f in lemminx-linux lemminx-darwin lemminx-win32; do pushd ${f} && chmod u+x ${f}* && zip ../${f}.zip ${f}* && sha256sum ${f}* > ../${f}.sha256 && popd; done
+        run: for f in lemminx-linux lemminx-osx-x86_64 lemminx-win32; do pushd ${f} && chmod u+x ${f}* && zip ../${f}.zip ${f}* && sha256sum ${f}* > ../${f}.sha256 && popd; done
       - name: Release Binary Artifacts
         if: steps.cache-last-commit.outputs.cache-hit != 'true'
         uses: "marvinpinto/action-automatic-releases@latest"


### PR DESCRIPTION
- lemminx-darwin -> lemminx-osx-x86_64
- Fixes #729 

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>