### PR TITLE
Added documentation for `XML: Restart Language Server`

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -25,3 +25,7 @@ When the [Server Cache Path](Preferences.md#server-cache-path) is activated, the
 This command re-triggers the [XML Validation](Validation.md#xml-validation) for the all opened XML files.
 
 When the [Server Cache Path](Preferences.md#server-cache-path) is activated, the command clears the remote grammar cache and revalidates all opened files.
+
+## Restart XML Language Server
+
+This command restarts the XML language server.

--- a/package.json
+++ b/package.json
@@ -616,7 +616,7 @@
       },
       {
         "command": "xml.restart.language.server",
-        "title": "Restart Language Server",
+        "title": "Restart XML Language Server",
         "category": "XML"
       }
     ],


### PR DESCRIPTION
Added documentation for `XML: Restart Language Server`.

As per https://github.com/redhat-developer/vscode-xml/pull/551#pullrequestreview-1045491718

Signed-off-by: Alexander Chen <alchen@redhat.com>