### PR TITLE
Set xml.format.preserveAttributeLineBreaks to true by default

### DIFF
--- a/docs/Formatting.md
+++ b/docs/Formatting.md
@@ -150,7 +150,7 @@ No changes to quotes will occur during formatting if `xml.format.enforceQuoteSty
 
 ### xml.format.preserveAttributeLineBreaks
 
-Preserve line breaks that appear before and after attributes. This setting is overridden if [xml.format.splitAttributes](#xmlformatsplitattributes) is set to `true`. Default is `false`.
+Preserve line breaks that appear before and after attributes. This setting is overridden if [xml.format.splitAttributes](#xmlformatsplitattributes) is set to `true`. Default is `true`.
 
 If set to `true`, formatting does not change the following document:
 

--- a/package.json
+++ b/package.json
@@ -316,8 +316,8 @@
         },
         "xml.format.preserveAttributeLineBreaks": {
           "type": "boolean",
-          "default": false,
-          "markdownDescription": "Preserve line breaks that appear before and after attributes. This setting is overridden if `#xml.format.splitAttributes#` is set to `true`. Default is `false`. See [here](command:xml.open.docs?%5B%7B%22page%22%3A%22Formatting%22%2C%22section%22%3A%22xmlformatpreserveattributelinebreaks%22%7D%5D) for more information.",
+          "default": true,
+          "markdownDescription": "Preserve line breaks that appear before and after attributes. This setting is overridden if `#xml.format.splitAttributes#` is set to `true`. Default is `true`. See [here](command:xml.open.docs?%5B%7B%22page%22%3A%22Formatting%22%2C%22section%22%3A%22xmlformatpreserveattributelinebreaks%22%7D%5D) for more information.",
           "scope": "window"
         },
         "xml.format.preserveEmptyContent": {


### PR DESCRIPTION
Fixes #748

Requires https://github.com/eclipse/lemminx/pull/1264

Signed-off-by: Jessica He <jhe@redhat.com>