### PR TITLE
Set xml.format.xsiSchemaLocationSplit to onPair by default

### DIFF
--- a/docs/Formatting.md
+++ b/docs/Formatting.md
@@ -386,7 +386,7 @@ If it is set to `true`, the above document becomes:
 ***
 ### xml.format.xsiSchemaLocationSplit
 
-  Used to configure how to format the content of `xsi:schemaLocation`.
+  Used to configure how to format the content of `xsi:schemaLocation`.  Defaults to `onPair`
 
   To explain the different settings, we will use this xml document as an example:
   ```xml

--- a/package.json
+++ b/package.json
@@ -375,8 +375,8 @@
             "Put a new line after each URI, arranging the content into pairs of namespace and URI.",
             "Ignore `xsi:schemaLocation` content formatting."
           ],
-          "default": "none",
-          "markdownDescription": "Split `xsi:schemaLocation` content. Default is `none`. Not supported by the experimental formatter. See [here](command:xml.open.docs?%5B%7B%22page%22%3A%22Formatting%22%2C%22section%22%3A%22xmlformatxsischemalocationsplit%22%7D%5D) for more information",
+          "default": "onPair",
+          "markdownDescription": "Split `xsi:schemaLocation` content. Default is `onPair`. Not supported by the experimental formatter. See [here](command:xml.open.docs?%5B%7B%22page%22%3A%22Formatting%22%2C%22section%22%3A%22xmlformatxsischemalocationsplit%22%7D%5D) for more information",
           "scope": "window"
         },
         "xml.format.splitAttributes": {


### PR DESCRIPTION
Fixes #749 

Requires https://github.com/eclipse/lemminx/pull/1267

Signed-off-by: Jessica He <jhe@redhat.com>