### PR TITLE
Update description for spaceBeforeEmptyCloseTag with experimental formatter

### DIFF
--- a/docs/Formatting.md
+++ b/docs/Formatting.md
@@ -349,8 +349,6 @@ If it is set to `true`, the above document becomes:
   <tag />
   ```
 
-**Not supported by the experimental formatter.**
-
 ***
 
 ### files.insertFinalNewline

--- a/package.json
+++ b/package.json
@@ -360,7 +360,7 @@
         "xml.format.spaceBeforeEmptyCloseTag": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "Insert space before end of self closing tag. \nExample:\n  ```<tag/> -> <tag />```. Not supported by the experimental formatter. Default is `true`. See [here](command:xml.open.docs?%5B%7B%22page%22%3A%22Formatting%22%2C%22section%22%3A%22xmlformatspacebeforeemptyclosetag%22%7D%5D) for more information.",
+          "markdownDescription": "Insert space before end of self closing tag. \nExample:\n  ```<tag/> -> <tag />```. Default is `true`. See [here](command:xml.open.docs?%5B%7B%22page%22%3A%22Formatting%22%2C%22section%22%3A%22xmlformatspacebeforeemptyclosetag%22%7D%5D) for more information.",
           "scope": "window"
         },
         "xml.format.xsiSchemaLocationSplit": {


### PR DESCRIPTION
Fixes https://github.com/eclipse/lemminx/issues/1245

Requires https://github.com/eclipse/lemminx/pull/1284

Signed-off-by: Jessica He <jhe@redhat.com>