### PR TITLE
Fix syntax coloration with element/attribute which can contains '-'

### DIFF
--- a/syntaxes/rnc.tmLanguage.json
+++ b/syntaxes/rnc.tmLanguage.json
@@ -28,7 +28,7 @@
 				"name": "entity.other.attribute.rnc"
 			}
 		},
-		"match": "\\b(attribute)\\s+([a-zA-Z][a-zA-Z_0-9]*)\\s*\\{",
+		"match": "\\b(attribute)\\s+([a-zA-Z][-a-zA-Z_0-9]*)\\s*\\{",
 		"name": "meta.declaration.attribute.rnc"
 	},
 	{
@@ -43,7 +43,7 @@
 				"name": "entity.other.element.rnc"
 			}
 		},
-		"match": "\\b(element)\\s+([a-zA-Z][a-zA-Z_0-9]*)\\s*\\{",
+		"match": "\\b(element)\\s+([a-zA-Z][-a-zA-Z_0-9]*)\\s*\\{",
 		"name": "meta.declaration.element.rnc"
 	},
 	{


### PR DESCRIPTION
Fix syntax coloration with element/attribute which can contains '-'

Signed-off-by: azerr <azerr@redhat.com>

This PR is a smal fix to support `-` for attribute/element name.

Given this rnc file:

```
element addressBook {
  element my-card {
    attribute my-id { text },
    element name { text },
    element email { text }
  }*
}
```

With the master we have:

![image](https://user-images.githubusercontent.com/1932211/195901057-86e34982-bc84-4aee-bcf1-63df72a0651d.png)

With the PR element/attribute is colorized correctly (not blank)

![image](https://user-images.githubusercontent.com/1932211/195900845-c6f72ef7-735f-4d92-bc7c-77d0de2ba661.png)
