### PR TITLE
Disable xml.format.maxLineWidth by default

### DIFF
--- a/docs/Formatting.md
+++ b/docs/Formatting.md
@@ -593,7 +593,7 @@ Element names for which spaces will be preserved. Defaults is the following arra
 
 ### xml.format.maxLineWidth
 
-Max line width. Default is `80`.
+Max line width. Set to `0` to disable this setting. Default is `0`.
 
 **This setting is only available with experimental formatter.**
 

--- a/package.json
+++ b/package.json
@@ -330,8 +330,8 @@
         },
         "xml.format.maxLineWidth": {
           "type": "integer",
-          "default": 80,
-          "markdownDescription": "Max line width. Default is `80`. Supported only with experimental formatter. See [here](command:xml.open.docs?%5B%7B%22page%22%3A%22Formatting%22%2C%22section%22%3A%22xmlformatmaxlinewidth%22%7D%5D) for more information.",
+          "default": 0,
+          "markdownDescription": "Max line width. Set to `0` to disable this setting. Default is `0`. Supported only with experimental formatter. See [here](command:xml.open.docs?%5B%7B%22page%22%3A%22Formatting%22%2C%22section%22%3A%22xmlformatmaxlinewidth%22%7D%5D) for more information.",
           "scope": "window"
         },
         "xml.format.preserveAttributeLineBreaks": {


### PR DESCRIPTION
Set the default value of `xml.format.maxLineWidth` to `0`.

Signed-off-by: Jessica He <jhe@redhat.com>