### PR TITLE
Add MEI, TEI, SVG as keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "dtd",
     "RelaxNG",
     "rng",
-    "rnc"
+    "rnc",
+    "TEI",
+    "MEI",
+    "SVG"
   ],
   "xmlServer": {
     "version": "0.23.0"


### PR DESCRIPTION
As vscode-xml can supports MEI, TEI and SVG, it should be nice to add those keywords when user will search extension:

 * `MEI` : https://music-encoding.org/
 * `TEI` : https://tei-c.org/
 * `SVG`: https://developer.mozilla.org/en-US/docs/Web/SVG