### PR TITLE
lemminx logfile: fallback to global storage

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@
 import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
-import { ExtensionContext, extensions, languages } from "vscode";
+import { ExtensionContext, Uri, extensions, languages } from "vscode";
 import { Executable, LanguageClient } from 'vscode-languageclient/node';
 import { XMLExtensionApi } from './api/xmlExtensionApi';
 import { getXmlExtensionApiImplementation } from './api/xmlExtensionApiImplementation';
@@ -49,11 +49,8 @@ export async function activate(context: ExtensionContext): Promise<XMLExtensionA
     requirementsData = {} as requirements.RequirementsData;
   }
 
-  let storagePath: string = context.storagePath;
-  if (!storagePath) {
-    storagePath = os.homedir() + "/.lemminx";
-  }
-  const logfile = path.resolve(storagePath + '/lemminx.log');
+  const storageUri = context.storageUri ?? context.globalStorageUri;
+  const logfile = Uri.joinPath(storageUri, 'lemminx.log').fsPath;
   await fs.ensureDir(context.globalStorageUri.fsPath);
   await cleanUpHeapDumps(context);
 


### PR DESCRIPTION
when opening an xml file outside of a workspace, this extension always create a folder `~/.lemminx` to store the language server log file (even when the `xml.server.workDir` preference is set to some other directory)

since it uses the workspace storage in the context of a workspace, it seems more sensible to fallback to the global storage instead.
(i also consider creating random folders in users' homes bad form but that's just preference)