### PR TITLE
Combine 'startup' and 'server.initialized' telemetry events

### DIFF
--- a/src/client/xmlClient.ts
+++ b/src/client/xmlClient.ts
@@ -35,7 +35,12 @@ export async function startLanguageClient(context: ExtensionContext, executable:
   languageClient = new LanguageClient('xml', 'XML Support', executable, languageClientOptions);
 
   languageClient.onTelemetry(async (e: TelemetryEvent) => {
-    return Telemetry.sendTelemetry(e.name, e.properties);
+    if (e.name === Telemetry.SERVER_INITIALIZED_EVT) {
+      e.properties[Telemetry.SETTINGS_EVT] = {
+        preferBinary: (getXMLConfiguration()['server']['preferBinary'] as boolean)
+      };
+      return Telemetry.sendTelemetry(Telemetry.STARTUP_EVT, e.properties);
+    }
   });
 
   context.subscriptions.push(languageClient.start());

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,9 +33,6 @@ let languageClient: LanguageClient;
 export async function activate(context: ExtensionContext): Promise<XMLExtensionApi> {
 
   await Telemetry.startTelemetry(context);
-  Telemetry.sendTelemetry(Telemetry.SETTINGS_EVT, {
-    preferBinary: (getXMLConfiguration()['server']['preferBinary'] as boolean)
-  });
 
   registerClientOnlyCommands(context);
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,5 +1,6 @@
 import { getRedHatService, TelemetryService } from "@redhat-developer/vscode-redhat-telemetry";
 import { ExtensionContext } from "vscode";
+import { getXMLConfiguration } from "./settings/settings";
 
 /**
  * Wrap vscode-redhat-telemetry to suit vscode-xml
@@ -11,6 +12,8 @@ export const OPEN_OOM_DOCS_EVT = "xml.open.oom.docs.link";
 export const SETTINGS_EVT = "xml.settings";
 export const BINARY_DOWNLOAD_EVT = "xml.binary.download";
 export const JAVA_OOM_EVT = "xml.java.oom";
+export const STARTUP_EVT = "startup";
+export const SERVER_INITIALIZED_EVT = "server.initialized";
 
 export const BINARY_DOWNLOAD_STATUS_PROP = "status";
 
@@ -19,6 +22,7 @@ export const BINARY_DOWNLOAD_FAILED = "failed";
 export const BINARY_DOWNLOAD_ABORTED = "aborted";
 
 let _telemetryManager: TelemetryService = null;
+let serverInitializedReceived = false;
 
 /**
  * Starts the telemetry service
@@ -32,7 +36,16 @@ export async function startTelemetry(context: ExtensionContext): Promise<void> {
   }
   const redhatService = await getRedHatService(context);
   _telemetryManager = await redhatService.getTelemetryService();
-  return _telemetryManager.sendStartupEvent();
+  setTimeout(sendEmptyStartUp, 15000);
+  return;
+}
+
+function sendEmptyStartUp() {
+  if (!serverInitializedReceived) {
+    return sendTelemetry(STARTUP_EVT, {
+      "xml.settings.preferBinary": (getXMLConfiguration()['server']['preferBinary'] as boolean)
+    });
+  }
 }
 
 /**
@@ -45,6 +58,9 @@ export async function startTelemetry(context: ExtensionContext): Promise<void> {
 export async function sendTelemetry(eventName: string, data?: any): Promise<void> {
   if (!_telemetryManager) {
     throw new Error("The telemetry service for vscode-xml has not been started yet");
+  }
+  if (eventName === STARTUP_EVT) {
+    serverInitializedReceived = true;
   }
   return _telemetryManager.send({
     name: eventName,


### PR DESCRIPTION
* in the case where the `server.initialized` telemetry is successfully received by the client, it sends a `startup` telemetry including the properties in the `server.initialized` sent by the server side.
* if `server.initialized` is never received by the client, there is a 15 second time out to catch this, then an empty `startup` telemetry is sent with no properties. 

Fixes #818 

Signed-off-by: Jessica He <jhe@redhat.com>