### PR TITLE
Fix lint.yaml build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Join the chat at https://gitter.im/redhat-developer/vscode-xml](https://img.shields.io/gitter/room/redhat-developer/vscode-xml?color=ED0060&style=for-the-badge&logo=gitter)](https://gitter.im/redhat-developer/vscode-xml?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Visual Studio Marketplace](https://img.shields.io/visual-studio-marketplace/v/redhat.vscode-xml?color=informational&logo=visualstudiocode&style=for-the-badge&label=VS%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-xml)
 [![Installs](https://img.shields.io/visual-studio-marketplace/i/redhat.vscode-xml?logo=visualstudiocode&color=informational&style=for-the-badge)](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-xml)
-[![eslint github action](https://img.shields.io/github/workflow/status/redhat-developer/vscode-xml/lint?label=eslint&logo=eslint&style=for-the-badge)](https://github.com/redhat-developer/vscode-xml/actions/workflows/lint.yaml?query=branch%3Amain)
+[![eslint github action](https://img.shields.io/github/actions/workflow/status/redhat-developer/vscode-xml/lint.yaml?branch=main&label=eslint&logo=eslint&style=for-the-badge)](https://github.com/redhat-developer/vscode-xml/actions/workflows/lint.yaml?query=branch%3Amain)
 
 ### [**NO LONGER REQUIRES JAVA!**](#Requirements) *since v0.15.0*
 


### PR DESCRIPTION
See badges/shields#8671
<img width="759" alt="Screenshot 2023-01-03 at 18 20 16" src="https://user-images.githubusercontent.com/148698/210408447-c57b18c9-396a-42d3-b5ab-e22e85118ce6.png">

Signed-off-by: Fred Bricon <fbricon@gmail.com>