### PR TITLE
Upversion to 0.25.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-xml",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-xml",
   "displayName": "XML",
   "description": "XML Language Support by Red Hat",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "author": "Red Hat",
   "publisher": "redhat",
   "icon": "icons/icon128.png",
@@ -22,7 +22,7 @@
     "SVG"
   ],
   "xmlServer": {
-    "version": "0.24.0"
+    "version": "0.25.0"
   },
   "binaryServerDownloadUrl": {
     "linux": "https://github.com/redhat-developer/vscode-xml/releases/download/latest/lemminx-linux.zip",


### PR DESCRIPTION
Let's go to 0.25.0 for now so that we continue using that in pre-releases (as opposed to something containing 1.0.0). Once we get approval to go 1.0.0, we can change the version just before releasing.

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>