### PR TITLE
Changelog for 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [0.26.0](https://github.com/redhat-developer/vscode-xml/milestone/34?closed=1) (July 10, 2023)
+
+### Bug Fixes
+
+ * `xml.foldings.includeClosingTagInFold` has no effect in binary mode. See [#1523](https://github.com/eclipse/lemminx/issues/1523).
+ * Fix regression in "Auto indent" setting of XML/XSD files. See [#899](https://github.com/redhat-developer/vscode-xml/issues/899).
+
 ## [0.25.0](https://github.com/redhat-developer/vscode-xml/milestone/33?closed=1) (April 19, 2023)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-xml",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-xml",
   "displayName": "XML",
   "description": "XML Language Support by Red Hat",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "author": "Red Hat",
   "publisher": "redhat",
   "icon": "icons/icon128.png",
@@ -22,7 +22,7 @@
     "SVG"
   ],
   "xmlServer": {
-    "version": "0.25.0"
+    "version": "0.26.1"
   },
   "binaryServerDownloadUrl": {
     "linux": "https://github.com/redhat-developer/vscode-xml/releases/download/latest/lemminx-linux.zip",


### PR DESCRIPTION
- Upversion to 0.26.0
- Use LemMinX 0.26.1

Do we take advantage of the 2 enhancements coming from the LemMinX side in vscode-xml ? We don't have any code actions that aren't associated with a diagnostic ? Our rename functionality doesn't currently have any cases for functioning across documents ?