### PR TITLE
For the Linux native image builds, use Ubuntu 20.04.

### DIFF
--- a/.github/workflows/native-image.yaml
+++ b/.github/workflows/native-image.yaml
@@ -26,11 +26,11 @@
       strategy:
         fail-fast: true
         matrix:
-          os: [macos-latest, ubuntu-latest]
+          os: [macos-latest, ubuntu-20.04]
           include:
             - os: macos-latest
               label: 'osx-x86_64'
-            - os: ubuntu-latest
+            - os: ubuntu-20.04
               label: 'linux'
       steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
- Fixed #916
- Recent Linux distros include GLIBC 2.34, which broke compatibility with older versions, so use Ubuntu 20.04 to have better support