### PR TITLE
Update GH Actions release workflow

### DIFF
--- a/.github/workflows/native-image.yaml
+++ b/.github/workflows/native-image.yaml
@@ -21,8 +21,8 @@
       runs-on: ${{ matrix.os }}
       needs: setup-xml-version
       env:
-        GRAALVM_VERSION: 22.0.0.2
-        GRAALVM_JAVA: java17
+        GRAALVM_VERSION: 22.3.3
+        GRAALVM_JAVA: 17
       strategy:
         fail-fast: true
         matrix:
@@ -51,15 +51,15 @@
         uses: actions/cache@v2
         with:
           path: |
-            /opt/hostedtoolcache/GraalVM
-            ~/hostedtoolcache/GraalVM
+            /opt/hostedtoolcache/graalvm-ce-*
+            ~/hostedtoolcache/graalvm-ce-*
           key: ${{ runner.os }}-graalvm-${{env.GRAALVM_VERSION}}
           restore-keys: |
             ${{ runner.os }}-graalvm-
-      - uses: DeLaGuardo/setup-graalvm@48f2bf339ab7d35e31029b1822a213681fdfc42e #v5.0
+      - uses: graalvm/setup-graalvm@0e29e36dce77b07eb899abac809c2fce9d60c140 #v1.1.3.1
         with:
-          graalvm: ${{env.GRAALVM_VERSION}}
-          java: ${{env.GRAALVM_JAVA}}
+          version: ${{env.GRAALVM_VERSION}}
+          java-version: ${{env.GRAALVM_JAVA}}
       - run: ./mvnw -B package -Dnative -DskipTests $([ $(uname -s) = Linux ] && echo "-Dgraalvm.static=-H:+StaticExecutableWithDynamicLibC") -Dcbi.jarsigner.skip=true
       - run: rm org.eclipse.lemminx/target/*.build_artifacts.txt
       - run: mv org.eclipse.lemminx/target/lemminx-* lemminx-${{ matrix.label }}
@@ -72,8 +72,8 @@
       runs-on: windows-latest
       needs: setup-xml-version
       env:
-        GRAALVM_VERSION: 22.0.0.2
-        GRAALVM_JAVA: java17
+        GRAALVM_VERSION: 22.3.3
+        GRAALVM_JAVA: 17
       steps:
       - name: Check out LemMinX
         uses: actions/checkout@v2
@@ -94,15 +94,15 @@
         uses: actions/cache@v2
         with:
           path: |
-            C:\hostedtoolcache\windows\GraalVM
+            C:\hostedtoolcache\windows\graalvm-ce-*
           key: ${{ runner.os }}-graalvm-${{env.GRAALVM_VERSION}}
           restore-keys: |
             ${{ runner.os }}-graalvm-
       - uses: ilammy/msvc-dev-cmd@7315a94840631165970262a99c72cfb48a65d25d #v1.12.0
-      - uses: DeLaGuardo/setup-graalvm@48f2bf339ab7d35e31029b1822a213681fdfc42e #v5.0
+      - uses: graalvm/setup-graalvm@0e29e36dce77b07eb899abac809c2fce9d60c140 #v1.1.3.1
         with:
-          graalvm: ${{env.GRAALVM_VERSION}}
-          java: ${{env.GRAALVM_JAVA}}
+          version: ${{env.GRAALVM_VERSION}}
+          java-version: ${{env.GRAALVM_JAVA}}
       - run: .\mvnw.cmd -B package -Dnative -DskipTests -D "cbi.jarsigner.skip=true"
       - run: mv org.eclipse.lemminx\target\lemminx-*.exe lemminx-win32.exe
       - uses: actions/upload-artifact@v3
@@ -110,35 +110,3 @@
           name: lemminx-win32
           path: lemminx-win32.exe
           if-no-files-found: error
-    release-binary-artifacts:
-      needs: [build-binary-unix, build-binary-windows]
-      runs-on: ubuntu-latest
-      steps:
-      - uses: actions/checkout@v2
-        with:
-          repository: 'eclipse/lemminx'
-          fetch-depth: 2
-      - run: git rev-parse HEAD^ > lastCommit
-      - name: Check New Changes To LS
-        id: cache-last-commit
-        uses: actions/cache@v2
-        with:
-          path: lastCommit
-          key: lastCommit-${{ hashFiles('lastCommit') }}
-      - name: Retrieve Binary Artifacts
-        if: steps.cache-last-commit.outputs.cache-hit != 'true'
-        uses: actions/download-artifact@v3
-      - name: Prepare Binary Artifacts
-        if: steps.cache-last-commit.outputs.cache-hit != 'true'
-        run: for f in lemminx-linux lemminx-osx-x86_64 lemminx-win32; do pushd ${f} && chmod u+x ${f}* && zip ../${f}.zip ${f}* && sha256sum ${f}* > ../${f}.sha256 && popd; done
-      - name: Release Binary Artifacts
-        if: steps.cache-last-commit.outputs.cache-hit != 'true'
-        uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 #v1.2.1
-        with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "latest"
-          prerelease: true
-          title: "Development Build"
-          files: |
-            lemminx-*.zip
-            lemminx-*.sha256

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: release
 
 on:
+    schedule:
+      - cron: '0 8 * * *'
     workflow_dispatch:
       inputs:
         publishPreRelease:
@@ -28,7 +30,36 @@ on:
             - 'false'
           default: 'false'
 jobs:
+  should-build-change:
+    runs-on: ubuntu-latest
+    outputs:
+        repo-cache-hit: ${{ steps.cache-last-commit.outputs.cache-hit }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: 'eclipse/lemminx'
+          fetch-depth: 2
+          path: lemminx
+      - uses: actions/checkout@v3
+        with:
+          repository: 'redhat-developer/vscode-xml'
+          fetch-depth: 2
+          path: vscode-xml
+      - run: |
+          pushd lemminx
+          git rev-parse HEAD >> ../lastCommit
+          popd
+          pushd vscode-xml
+          git rev-parse HEAD >> ../lastCommit
+      - name: Check New Changes
+        id: cache-last-commit
+        uses: actions/cache@v2
+        with:
+          path: lastCommit
+          key: lastCommit-${{ hashFiles('lastCommit') }}
   build-binaries-job:
+    needs: should-build-change
+    if: ${{ needs.should-build-change.outputs.repo-cache-hit == 'false' || github.event_name != 'schedule' }}
     uses: rgrunber/vscode-xml/.github/workflows/native-image.yaml@main
     with:
       publishPreRelease: ${{ github.event_name == 'schedule' || inputs.publishPreRelease == 'true' }}


### PR DESCRIPTION
The main purpose of this change is to add the ability to publish a pre-release when there are changes to either lemminx or vscode-xml. This is done by having a daily scheduled workflow that has a job which checks out the 2 repositories, and determines if the recent commit (from both repos) have already been encountered in a previous build. This check is skipped if the build was manually triggered (assume the maintainer knows what they're doing).

- https://github.com/DeLaGuardo/setup-graalvm/ has been archived since April 2023, so we should use https://github.com/graalvm/setup-graalvm
- No need for workflow to release binary artifacts of lemminx in the native-image job, because we already do it in vscode-xml releases, (eg. https://github.com/redhat-developer/vscode-xml/releases/tag/0.26.1 .

- [x] Verify that the new binaries (resulting from the new setup-graalvm with version 22.3.3) work as expected.