### PR TITLE
Fix build mechanism for determining if new changes exist.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,8 +59,8 @@ jobs:
           key: lastCommit-${{ hashFiles('lastCommit') }}
   build-binaries-job:
     needs: should-build-change
-    if: ${{ needs.should-build-change.outputs.repo-cache-hit == 'false' || github.event_name != 'schedule' }}
-    uses: rgrunber/vscode-xml/.github/workflows/native-image.yaml@main
+    if: ${{ needs.should-build-change.outputs.repo-cache-hit != 'true' || github.event_name != 'schedule' }}
+    uses: redhat-developer/vscode-xml/.github/workflows/native-image.yaml@main
     with:
       publishPreRelease: ${{ github.event_name == 'schedule' || inputs.publishPreRelease == 'true' }}
   packaging-job:


### PR DESCRIPTION
- Update re-usable workflow reference to redhat-developer

Continuing from https://github.com/redhat-developer/vscode-xml/pull/933

As per my comment in https://github.com/actions/cache/pull/1160#issuecomment-1731697259 . A cache-miss does not set the `outputs.cache-hit` value to `'false'`. It appears to be empty in this case, so we should explicitly check for `!= 'true'`