### PR TITLE
XML support crashes when workspace folders are empty

### DIFF
--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -9,7 +9,7 @@ import { TextDocument, Uri, workspace, WorkspaceFolder } from "vscode";
  */
  export function getWorkspaceUri(document: TextDocument): Uri | undefined {
   const currentWorkspace: WorkspaceFolder = (document && document.uri) ? workspace.getWorkspaceFolder(document.uri) : undefined;
-  return ((currentWorkspace && currentWorkspace.uri) || (workspace.workspaceFolders && workspace.workspaceFolders[0].uri));
+  return ((currentWorkspace && currentWorkspace.uri) || (workspace.workspaceFolders && workspace.workspaceFolders.length > 0 && workspace.workspaceFolders[0].uri));
 }
 
 /**


### PR DESCRIPTION
XML support crashes when workspace folders are empty

Fixes #940