### PR TITLE
Use @vscode/vsce instead of vsce.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
         with:
           node-version: '18'
       - name: Install dependencies
-        run: npm install -g typescript "vsce" "ovsx"
+        run: npm install -g typescript "@vscode/vsce" "ovsx"
       - run: echo "XML_SERVER_VERSION=$(cat package.json | jq -r .xmlServer.version)" >> $GITHUB_ENV
       - name: Download LemMinX Server Uber Jar
         env:
@@ -176,7 +176,7 @@ jobs:
         with:
           node-version: '18'
       - name: Install dependencies
-        run: npm install -g typescript "vsce" "ovsx"
+        run: npm install -g typescript "@vscode/vsce" "ovsx"
       - run: echo "XML_SERVER_VERSION=$(cat package.json | jq -r .xmlServer.version)" >> $GITHUB_ENV
       - name: Set the link to download the binary server
         env:


### PR DESCRIPTION
Saw this in a build at the end of February.

```
Publishing 'redhat.vscode-xml (darwin-arm64) v0.26.2024022308'...
Extension URL (might take a few minutes): https://marketplace.visualstudio.com/items?itemName=redhat.vscode-xml
Hub URL: https://marketplace.visualstudio.com/manage/publishers/redhat/extensions/vscode-xml/hub
Published redhat.vscode-xml (darwin-arm64) v0.26.2024022308.
Publishing 'redhat.vscode-xml (darwin-x64) v0.26.2024022308'...
Version 0.26.2024022308 is already published. Skipping publish.
Publishing 'redhat.vscode-xml (linux-x64) v0.26.2024022308'...
Version 0.26.2024022308 is already published. Skipping publish.
Publishing 'redhat.vscode-xml (win32-x64) v0.26.2024022308'...
Version 0.26.2024022308 is already published. Skipping publish.
Publishing 'redhat.vscode-xml v0.26.2024022308'...
Version 0.26.2024022308 is already published. Skipping publish.
```

How could `--skip-duplicate` think a vsixs of other platforms with the same version are the same ? It's basically, https://github.com/microsoft/vscode-vsce/issues/868 and we just need to update `vsce`.

This is probably something we missed in https://github.com/redhat-developer/vscode-xml/pull/840/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R57 because the [Jenkinsfile certainly had it correct](https://github.com/redhat-developer/vscode-xml/blob/057ed30da5d4aaafd9dd1b3c1075b7700a8b60ca/Jenkinsfile#L7).