### PR TITLE
Fix binary server startup on MacOS aarch64.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,6 +153,17 @@ jobs:
           name: lemminx-uber-jar
           path: server/org.eclipse.lemminx*-uber.jar
           if-no-files-found: error
+      - name: Publish to GH Pre-Release Tab
+        if: ${{ github.event_name == 'schedule' || inputs.publishPreRelease == 'true' }}
+        uses: "marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest"
+          prerelease: true
+          title: "Development Build"
+          files: |
+            ../staging/zips/lemminx-*
+            ../staging/checksums/lemminx-*
       - name: Publish to GH Release Tab
         if: ${{ inputs.publishToMarketPlace == 'true' && inputs.publishToOVSX == 'true' }}
         uses: "marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "binaryServerDownloadUrl": {
     "linux": "https://github.com/redhat-developer/vscode-xml/releases/download/latest/lemminx-linux.zip",
     "osx-x86_64": "https://github.com/redhat-developer/vscode-xml/releases/download/latest/lemminx-osx-x86_64.zip",
+    "osx-aarch_64": "https://github.com/redhat-developer/vscode-xml/releases/download/latest/lemminx-osx-aarch_64.zip",
     "win32": "https://github.com/redhat-developer/vscode-xml/releases/download/latest/lemminx-win32.zip"
   },
   "capabilities": {

--- a/src/server/binary/binaryServerStarter.ts
+++ b/src/server/binary/binaryServerStarter.ts
@@ -214,8 +214,12 @@ function getBinaryEnvironment(): any {
 function getServerBinaryNameWithoutExtension(): string {
   switch (os.platform()) {
     case 'darwin':
-      // FIXME: once we support Apple ARM, incorporate the architecture into this string
-      return 'lemminx-osx-x86_64';
+      switch (os.arch()) {
+        case 'arm64':
+          return 'lemminx-osx-aarch_64';
+        default:
+          return 'lemminx-osx-x86_64';
+      }
     default:
       return `lemminx-${os.platform}`;
   }


### PR DESCRIPTION
- Fixes #974 

I think this was the issue. Let's just wait to confirm with the workarounds mentioned.