### PR TITLE
fix the error that "/" in attribute value make indentation problem

### DIFF
--- a/src/client/indentation.ts
+++ b/src/client/indentation.ts
@@ -11,12 +11,12 @@ export function getIndentationRules(): LanguageConfiguration {
     },
     onEnterRules: [
       {
-        beforeText: new RegExp(`<([_:\\w][_:\\w-.\\d]*)([^/>]*(?!/)>)[^<]*$`, 'i'),
+        beforeText: new RegExp(`<([_:\\w][_:\\w-.\\d]*)(([^/>]|/[^>]*["'])*(?!/)>)[^<]*$`, 'i'),
         afterText: /^<\/([_:\w][_:\w-.\d]*)\s*>/i,
         action: { indentAction: IndentAction.IndentOutdent }
       },
       {
-        beforeText: new RegExp(`<(\\w[\\w\\d]*)([^/>]*(?!/)>)[^<]*$`, 'i'),
+        beforeText: new RegExp(`<(\\w[\\w\\d]*)(([^/>]|/[^>]*["'])*(?!/)>)[^<]*$`, 'i'),
         action: { indentAction: IndentAction.Indent }
       }
     ]

--- a/src/client/indentation.ts
+++ b/src/client/indentation.ts
@@ -11,12 +11,12 @@ export function getIndentationRules(): LanguageConfiguration {
     },
     onEnterRules: [
       {
-        beforeText: new RegExp(`<([_:\\w][_:\\w-.\\d]*)(([^/>]|/[^>]*["'])*(?!/)>)[^<]*$`, 'i'),
-        afterText: /^<\/([_:\w][_:\w-.\d]*)\s*>/i,
+        beforeText: /<(?:[_:\w][_:\w\-.\d]*)(?:(?:[^'"/>]|"[^"]*"|'[^']*')*?(?!\/)>)[^<]*$/i,
+        afterText: /^<\/(?:[_:\w][_:\w-.\d]*)\s*>/i,
         action: { indentAction: IndentAction.IndentOutdent }
       },
       {
-        beforeText: new RegExp(`<(\\w[\\w\\d]*)(([^/>]|/[^>]*["'])*(?!/)>)[^<]*$`, 'i'),
+        beforeText: /<(?:\w[\w\d]*)(?:(?:[^'"/>]|"[^"]*"|'[^']*')*?(?!\/)>)[^<]*$/i,
         action: { indentAction: IndentAction.Indent }
       }
     ]


### PR DESCRIPTION
https://github.com/redhat-developer/vscode-xml/blob/d4db83adf421ccede3a4264439c1264f69e47b0d/src/client/indentation.ts#L14

The current regex pattern used for matching non-self-closing XML tags fails to match tags that include attributes. Specifically, the pattern struggles with tags formatted like `<a type="text/json">`, which are not self-closing but contain attributes within them. The issue stems from the regex not adequately accounting for the presence of `/` characters within attribute values, which leads to incorrect or failed matches.

