### PR TITLE
Use the extension version in download URL for binary.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,14 +86,6 @@ jobs:
           node-version: '18'
       - name: Install dependencies
         run: npm install -g typescript "@vscode/vsce" "ovsx"
-      - run: echo "XML_SERVER_VERSION=$(cat package.json | jq -r .xmlServer.version)" >> $GITHUB_ENV
-      - name: Download LemMinX Server Uber Jar
-        env:
-            downloadLocation: https://github.com/redhat-developer/vscode-xml
-        if: "${{ inputs.publishToMarketPlace == 'true' || inputs.publishToOVSX == 'true' }}"
-        run: |
-          curl -Lo org.eclipse.lemminx-${{ env.XML_SERVER_VERSION }}-uber.jar https://repo.eclipse.org/content/repositories/lemminx-releases/org/eclipse/lemminx/org.eclipse.lemminx/${{ env.XML_SERVER_VERSION }}/org.eclipse.lemminx-${{ env.XML_SERVER_VERSION }}-uber.jar
-          sed -i -e "s|${{ env.downloadLocation }}/releases/download/latest|${{ env.downloadLocation }}/releases/download/${{ env.XML_SERVER_VERSION }}|g" package.json
       - name: Build vscode-xml
         run: |
           npm install
@@ -103,6 +95,17 @@ jobs:
         run: |
           npx gulp prepare_pre_release
           echo "publishPreReleaseFlag=--pre-release" >> $GITHUB_ENV
+      - name: Prepare Environment Variables
+        run: |
+          echo "XML_SERVER_VERSION=$(cat package.json | jq -r .xmlServer.version)" >> $GITHUB_ENV
+          echo "EXT_VERSION=$(cat package.json | jq -r .version)" >> $GITHUB_ENV
+      - name: Download LemMinX Server Uber Jar
+        env:
+            downloadLocation: https://github.com/redhat-developer/vscode-xml
+        if: "${{ inputs.publishToMarketPlace == 'true' || inputs.publishToOVSX == 'true' }}"
+        run: |
+          curl -Lo org.eclipse.lemminx-${{ env.XML_SERVER_VERSION }}-uber.jar https://repo.eclipse.org/content/repositories/lemminx-releases/org/eclipse/lemminx/org.eclipse.lemminx/${{ env.XML_SERVER_VERSION }}/org.eclipse.lemminx-${{ env.XML_SERVER_VERSION }}-uber.jar
+          sed -i -e "s|${{ env.downloadLocation }}/releases/download/latest|${{ env.downloadLocation }}/releases/download/${{ env.EXT_VERSION }}|g" package.json
       - run: |
           mkdir server/
           if [ -e org.eclipse.lemminx*-uber.jar ]; then
@@ -110,7 +113,6 @@ jobs:
           else
             cp ../staging/org.eclipse.lemminx*-uber.jar server/
           fi
-          echo "EXT_VERSION=$(cat package.json | jq -r .version)" >> $GITHUB_ENV
       - name: Download LemMinX Binary Artifacts
         uses: actions/download-artifact@v4
       - name: Prepare Binary Artifacts For Packaging
@@ -189,12 +191,6 @@ jobs:
           node-version: '18'
       - name: Install dependencies
         run: npm install -g typescript "@vscode/vsce" "ovsx"
-      - run: echo "XML_SERVER_VERSION=$(cat package.json | jq -r .xmlServer.version)" >> $GITHUB_ENV
-      - name: Set the link to download the binary server
-        env:
-            downloadLocation: https://github.com/redhat-developer/vscode-xml
-        if: ${{ inputs.publishToMarketPlace == 'true' }}
-        run: sed -i -e "s|${{ env.downloadLocation }}/releases/download/latest|${{ env.downloadLocation }}/releases/download/${{ env.XML_SERVER_VERSION }}|g" package.json
       - name: Download VSIX & LemMinX Server Uber Jar
         uses: actions/download-artifact@v4
       - name: Build vscode-xml
@@ -206,9 +202,9 @@ jobs:
         run: |
           npx gulp prepare_pre_release
           echo "publishPreReleaseFlag=--pre-release" >> $GITHUB_ENV
-      - run: |
-          mkdir server/
-          mv lemminx-uber-jar/org.eclipse.lemminx*-uber.jar server/
+      - name: Prepare Environment Variables
+        run: |
+          echo "XML_SERVER_VERSION=$(cat package.json | jq -r .xmlServer.version)" >> $GITHUB_ENV
           echo "EXT_VERSION=$(cat package.json | jq -r .version)" >> $GITHUB_ENV
       - name: Publish to VS Code Marketplace
         if: ${{ github.event_name == 'schedule' || inputs.publishToMarketPlace == 'true' || inputs.publishPreRelease == 'true' }}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "SVG"
   ],
   "xmlServer": {
-    "version": "0.28.1"
+    "version": "0.28.0"
   },
   "binaryServerDownloadUrl": {
     "linux": "https://github.com/redhat-developer/vscode-xml/releases/download/latest/lemminx-linux.zip",


### PR DESCRIPTION
- The language server version was used as the version for the download URL of the binary, but since the binaries are hosted under the vscode-xml release tab, it should match the vscode-xml release
- Remove some unnecessary steps from the release job

I also slightly refactored the ordering. The preparing of the pre-release affects the final version number, so extracting the version number must happen after. Any workflow that users the versions can occur immediately after.

Also set xmlServer/version back to 0.28.0 as we may end up doing a bug fix release for this, using the same language server.