### PR TITLE
Use Node 20 in release-job only.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Set Up NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install dependencies
         run: npm install -g typescript "@vscode/vsce" "ovsx"
       - name: Download VSIX & LemMinX Server Uber Jar


### PR DESCRIPTION
- ovsx 0.10.0 requires Node >= 20