### PR TITLE
docs/Troubleshooting.md: Specify how to switch to the binary server mode

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -27,7 +27,8 @@ You can kill the process by:
 If you are working with large XML files or referencing large schema files,
 this may lead to the language server running out of memory.
 The Java language server is more likely to run out memory than the binary language server.
-Switching to the binary language server
+[Switching to the binary language server](Preferences.md#server-binary-mode)
+(via the `xml.server.preferBinary` setting)
 or increasing the memory available to the Java language server could resolve this issue.
 
 If you get an Out of Memory Error, but aren't working with large XML files,


### PR DESCRIPTION
I got an out of memory error message when VS Code tried to parse a large XML file, and this generated a pop-up message in the bottom right:

![image](https://github.com/user-attachments/assets/6890ebf9-7de9-4a45-a300-130ddd2bf4f3)

The "More info..." button in the pop-up message pointed to a page displaying the `docs/Troubleshooting.md` page, focused on the "The Language Server Crashes Due to an Out Of Memory Error" section:

![image](https://github.com/user-attachments/assets/5a93eaa9-c8ee-4f5e-bdb1-2374fe0ee16e)

That was useful, as the message explained that I could swap to the binary language server to avoid the problem, but didn't specify how to do it.

This PR adds a link to the relevant section of `docs/Preferences.md` that one can follow to learn more about what these language server modes mean, as well as a reference to the specific settings path that needs to be modified to actually perform the swap. This matches the more detailed instructions that this page already includes regarding the other possible solution for this issue (i.e. increasing the memory available to the Java language server).

**Note:** I'm not sure if a relative link works here. Happy to swap the link to the full URL `https://github.com/redhat-developer/vscode-xml/blob/main/docs/Preferences.md#server-binary-mode` if necessary.