### PR TITLE
Fix crash of extension when proxy settings address has wrong format

### DIFF
--- a/src/settings/proxySettings.ts
+++ b/src/settings/proxySettings.ts
@@ -75,7 +75,7 @@ export function getProxySettings(): ProxySettings {
     return null;
   }
   const regexResult = HOST_AND_PORT_EXTRACTOR.exec(proxyAddress);
-  if (!regexResult[1]) {
+  if (!regexResult || !regexResult[1]) {
     return null;
   }
   const host: string = regexResult[1];
@@ -152,7 +152,7 @@ export function jvmArgsContainsProxySettings(jvmArgs: string): boolean {
   );
 }
 
-const HOST_AND_PORT_EXTRACTOR = /https?:\/\/([^:/]+)(?::([0-9]+))?/;
+const HOST_AND_PORT_EXTRACTOR = /(?:https?:\/\/)?([^:/]+)(?::([0-9]+))?/;
 
 const JVM_PROXY_HOST = 'http.proxyHost';
 const JVM_PROXY_PORT = 'http.proxyPort';


### PR DESCRIPTION
This PR should fix the following problem:

```
2024-11-22 14:07:45.651 [error] Activating extension redhat.vscode-xml failed due to an error:
2024-11-22 14:07:45.651 [error] TypeError: Cannot read properties of null (reading '1')
	at t.getProxySettings (/Users/userid/.vscode/extensions/redhat.vscode-xml-0.27.2024111708-darwin-arm64/dist/extension.js:2:354116)
```

reported at https://github.com/redhat-developer/vscode-xml/issues/154#issuecomment-2493802486

I think to reproduce the problem, proxy address have a wrong format (don't start with `https://`)

A simple test that I did in debug is:

```typescript
const HOST_AND_PORT_EXTRACTOR = /https?:\/\/([^:/]+)(?::([0-9]+))?/;
HOST_AND_PORT_EXTRACTOR .exec('foo") // -> returns undefined
```