### PR TITLE
Specify schemes for which XML will provide support

### DIFF
--- a/src/client/languageParticipants.ts
+++ b/src/client/languageParticipants.ts
@@ -6,6 +6,16 @@
 import { Event, EventEmitter, extensions } from 'vscode';
 import { DocumentFilter, DocumentSelector } from 'vscode-languageclient';
 
+const SCHEMES: string[] = [
+  'untitled',
+  'file',
+  'ftp',
+  'http',
+  'https',
+  'ssh',
+  'streamfile',
+];
+
 /**
  * XML language participant contribution.
  */
@@ -59,7 +69,16 @@ export function getLanguageParticipants(): LanguageParticipants {
 
   return {
     onDidChange: onDidChangeEmmiter.event,
-    get documentSelector() { return Array.from(languages); },
+    get documentSelector() {
+      return SCHEMES.flatMap(scheme => {
+        return Array.from(languages).map(language => {
+          return {
+            language,
+            scheme
+          } as DocumentFilter;
+        });
+      });
+    },
     hasLanguage(languageId: string) { return languages.has(languageId); },
     dispose: () => changeListener.dispose()
   };


### PR DESCRIPTION
I included a bunch of schemas that are used for remote files, so hopefully we don't drop support for editing remote files.

Fixes #1063