### PR TITLE
Fix extension warnings

### DIFF
--- a/src/client/tagClosing.ts
+++ b/src/client/tagClosing.ts
@@ -34,7 +34,7 @@ export function activateTagClosing(tagProvider: (document: TextDocument, positio
     if (!supportedLanguages[document.languageId]) {
       return;
     }
-    if (!workspace.getConfiguration(undefined, document.uri).get<boolean>(configName)) {
+    if (!workspace.getConfiguration().get<boolean>(configName)) {
       return;
     }
     isEnabled = true;

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -107,9 +107,8 @@ function verifyVMArgs() {
 }
 
 function verifyAutoClosing() {
-  const configXML = workspace.getConfiguration();
-  const closeTags = configXML.get("xml.completion.autoCloseTags");
-  const closeBrackets = configXML.get("[xml]")["editor.autoClosingBrackets"];
+  const closeTags = getXMLConfiguration().get('completion.autoCloseTags');
+  const closeBrackets = workspace.getConfiguration('editor', { languageId: 'xml' }).get('autoClosingBrackets');
   if (closeTags && closeBrackets != "never") {
     window.showWarningMessage(
       "The [xml].editor.autoClosingBrackets setting conflicts with xml.completion.autoCloseTags. It's recommended to disable it.",


### PR DESCRIPTION
We were accessing some scoped settings incorrectly; this should access them correctly.

Fixes #98