### PR TITLE
Drop support for Alpine Linux-specific version

### DIFF
--- a/.github/workflows/native-image.yaml
+++ b/.github/workflows/native-image.yaml
@@ -26,7 +26,7 @@
       strategy:
         fail-fast: true
         matrix:
-          label: [osx-x86_64, osx-aarch_64, linux, alpine]
+          label: [osx-x86_64, osx-aarch_64, linux]
           include:
             - label: osx-x86_64
               os: macos-13
@@ -35,9 +35,6 @@
             - label: linux
               os: ubuntu-22.04
               prop: -Dgraalvm.static=-H:+StaticExecutableWithDynamicLibC
-            - label: alpine
-              os: ubuntu-22.04
-              prop: -Dgraalvm.static=--static
       steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Prepare Binary Artifacts For Packaging
         run:  |
           mkdir -p ../staging/zips ../staging/checksums
-          for f in lemminx-{linux,alpine} lemminx-osx-{x86_64,aarch_64} lemminx-win32; do
+          for f in lemminx-linux lemminx-osx-{x86_64,aarch_64} lemminx-win32; do
             pushd ${f}
             chmod u+x ${f}*
             zip ../../staging/zips/${f}.zip ${f}*
@@ -130,7 +130,6 @@ jobs:
       - name: Package vscode-xml
         run: |
           declare -A targets
-          targets["alpine-x64"]=alpine
           targets["linux-x64"]=linux
           targets["win32-x64"]=win32
           targets["darwin-x64"]=osx-x86_64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Build
 
  * Add smoke tests for the binary server. See [#1075](https://github.com/redhat-developer/vscode-xml/issues/1075).
+ * Drop support for Alpine Linux-specific version. See [#1083](https://github.com/redhat-developer/vscode-xml/pull/1083)
 
 ## [0.28.1](https://github.com/redhat-developer/vscode-xml/milestone/40?closed=1) (April 9, 2025)
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "binaryServerDownloadUrl": {
     "linux": "https://github.com/redhat-developer/vscode-xml/releases/download/latest/lemminx-linux.zip",
-    "alpine": "https://github.com/redhat-developer/vscode-xml/releases/download/latest/lemminx-alpine.zip",
     "osx-x86_64": "https://github.com/redhat-developer/vscode-xml/releases/download/latest/lemminx-osx-x86_64.zip",
     "osx-aarch_64": "https://github.com/redhat-developer/vscode-xml/releases/download/latest/lemminx-osx-aarch_64.zip",
     "win32": "https://github.com/redhat-developer/vscode-xml/releases/download/latest/lemminx-win32.zip"

--- a/src/server/binary/binaryServerStarter.ts
+++ b/src/server/binary/binaryServerStarter.ts
@@ -207,23 +207,12 @@ function getBinaryEnvironment(): any {
 }
 
 /**
- * Returns the platform of the current operating system.
- * If the OS is Alpine Linux, it returns 'alpine'.
- * Otherwise, it returns the platform string provided by the 'os' module.
- *
- * @returns The platform of the current operating system.
- */
-function getPlatform (): NodeJS.Platform | 'alpine' {
-  return fs.existsSync('/etc/alpine-release') ? 'alpine' : os.platform();
-}
-
-/**
  * Returns the name of the server binary file for the current OS and architecture
  *
  * @return the name of the server binary file for the current OS and architecture
  */
 function getServerBinaryNameWithoutExtension(): string {
-  switch (getPlatform()) {
+  switch (os.platform()) {
     case 'darwin':
       switch (os.arch()) {
         case 'arm64':
@@ -232,7 +221,7 @@ function getServerBinaryNameWithoutExtension(): string {
           return 'lemminx-osx-x86_64';
       }
     default:
-      return `lemminx-${getPlatform()}`;
+      return `lemminx-${os.platform()}`;
   }
 }
 


### PR DESCRIPTION
We can't build a binary version of the language server for Alpine Linux any more due to bugs/limitations in GraalVM and changes to the runners in GitHub Actions.

It's _probably_ okay to drop Alpine Linux support, since Alpine Linux is usually used on servers instead of as a desktop operating system, and it's a real pain to set up as a desktop operating system.

Alpine Linux users should still be able to use the extension if they install Java.