### PR TITLE
ci: Reformatting of .github/workflows/*.yaml

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,6 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = false
 
-[*.{ts,js,json,md}]
+[*.{ts,js,json,md,yaml,yml}]
 indent_style = space
 indent_size = 2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,35 +1,34 @@
 name: Continuous Integration
-on: [ push, pull_request ]
+on: [push, pull_request]
 jobs:
-
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: npm i --also=dev
-    - name: Run TypeScript compiler (under webpack)
-      run: npm run compile
-    - name: Run ESLint
-      run: npm run eslint
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: npm i --also=dev
+      - name: Run TypeScript compiler (under webpack)
+        run: npm run compile
+      - name: Run ESLint
+        run: npm run eslint
 
   build-test-native-image:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-      with:
-        repository: 'eclipse/lemminx'
-    - uses: graalvm/setup-graalvm@557ffcf459751b4d92319ee255bf3bec9b73964c #v1.2.5
-      with:
-        distribution: graalvm-community
-        java-version: 17
-    - run: ./mvnw -B package -Dnative -DskipTests -Dgraalvm.static=-H:+StaticExecutableWithDynamicLibC -Dcbi.jarsigner.skip=true
-    - run: mv org.eclipse.lemminx/target/lemminx-* lemminx-linux
-    - uses: actions/upload-artifact@v4
-      with:
-        name: lemminx-linux
-        path: lemminx-linux
-        if-no-files-found: error
+      - uses: actions/checkout@v4
+        with:
+          repository: "eclipse/lemminx"
+      - uses: graalvm/setup-graalvm@557ffcf459751b4d92319ee255bf3bec9b73964c #v1.2.5
+        with:
+          distribution: graalvm-community
+          java-version: 17
+      - run: ./mvnw -B package -Dnative -DskipTests -Dgraalvm.static=-H:+StaticExecutableWithDynamicLibC -Dcbi.jarsigner.skip=true
+      - run: mv org.eclipse.lemminx/target/lemminx-* lemminx-linux
+      - uses: actions/upload-artifact@v4
+        with:
+          name: lemminx-linux
+          path: lemminx-linux
+          if-no-files-found: error
 
   smoke-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/native-image.yaml
+++ b/.github/workflows/native-image.yaml
@@ -1,44 +1,46 @@
-  name: native-image
-  on:
-    workflow_call:
-      inputs:
-        publishPreRelease:
-          description: 'Publish a pre-release ?'
-          required: true
-          type: string
-          default: 'true'
-  jobs:
-    setup-xml-version:
-      runs-on: ubuntu-latest
-      outputs:
-        xml-server-version: ${{ steps.setup-xml-version.outputs.XML_SERVER_VERSION }}
-      steps:
+name: native-image
+on:
+  workflow_call:
+    inputs:
+      publishPreRelease:
+        description: "Publish a pre-release ?"
+        required: true
+        type: string
+        default: "true"
+
+jobs:
+  setup-xml-version:
+    runs-on: ubuntu-latest
+    outputs:
+      xml-server-version: ${{ steps.setup-xml-version.outputs.XML_SERVER_VERSION }}
+    steps:
       - name: Check Out VS Code XML
         uses: actions/checkout@v4
       - id: setup-xml-version
         run: echo "XML_SERVER_VERSION=$(cat package.json | jq -r .xmlServer.version)" >> $GITHUB_OUTPUT
-    build-binary-unix:
-      runs-on: ${{ matrix.os }}
-      needs: setup-xml-version
-      env:
-        GRAALVM_DISTRO: graalvm-community
-        GRAALVM_JAVA: 17
-      strategy:
-        fail-fast: true
-        matrix:
-          label: [osx-x86_64, osx-aarch_64, linux]
-          include:
-            - label: osx-x86_64
-              os: macos-13
-            - label: osx-aarch_64
-              os: macos-latest
-            - label: linux
-              os: ubuntu-22.04
-              prop: -Dgraalvm.static=-H:+StaticExecutableWithDynamicLibC
-      steps:
+
+  build-binary-unix:
+    runs-on: ${{ matrix.os }}
+    needs: setup-xml-version
+    env:
+      GRAALVM_DISTRO: graalvm-community
+      GRAALVM_JAVA: 17
+    strategy:
+      fail-fast: true
+      matrix:
+        label: [osx-x86_64, osx-aarch_64, linux]
+        include:
+          - label: osx-x86_64
+            os: macos-13
+          - label: osx-aarch_64
+            os: macos-latest
+          - label: linux
+            os: ubuntu-22.04
+            prop: -Dgraalvm.static=-H:+StaticExecutableWithDynamicLibC
+    steps:
       - uses: actions/checkout@v4
         with:
-          repository: 'eclipse/lemminx'
+          repository: "eclipse/lemminx"
           ref: ${{ inputs.publishPreRelease == 'true' && 'main' || needs.setup-xml-version.outputs.xml-server-version }}
       - name: Cache Maven dependencies
         uses: actions/cache@v4
@@ -70,17 +72,18 @@
           name: lemminx-${{ matrix.label }}
           path: lemminx-${{ matrix.label }}
           if-no-files-found: error
-    build-binary-windows:
-      runs-on: windows-latest
-      needs: setup-xml-version
-      env:
-        GRAALVM_DISTRO: graalvm-community
-        GRAALVM_JAVA: 17
-      steps:
+
+  build-binary-windows:
+    runs-on: windows-latest
+    needs: setup-xml-version
+    env:
+      GRAALVM_DISTRO: graalvm-community
+      GRAALVM_JAVA: 17
+    steps:
       - name: Check out LemMinX
         uses: actions/checkout@v4
         with:
-          repository: 'eclipse/lemminx'
+          repository: "eclipse/lemminx"
           ref: ${{ inputs.publishPreRelease == 'true' && 'main' || needs.setup-xml-version.outputs.xml-server-version }}
       - name: Cache Maven dependencies
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,48 +1,49 @@
 name: release
 
 on:
-    schedule:
-      - cron: '0 8 * * *'
-    workflow_dispatch:
-      inputs:
-        publishPreRelease:
-          description: 'Publish a pre-release ?'
-          required: true
-          type: choice
-          options:
-            - 'true'
-            - 'false'
-          default: 'true'
-        publishToMarketPlace:
-          description: 'Publish to VS Code Marketplace ?'
-          required: true
-          type: choice
-          options:
-            - 'true'
-            - 'false'
-          default: 'false'
-        publishToOVSX:
-          description: 'Publish to OpenVSX Registry ?'
-          required: true
-          type: choice
-          options:
-            - 'true'
-            - 'false'
-          default: 'false'
+  schedule:
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+    inputs:
+      publishPreRelease:
+        description: "Publish a pre-release ?"
+        required: true
+        type: choice
+        options:
+          - "true"
+          - "false"
+        default: "true"
+      publishToMarketPlace:
+        description: "Publish to VS Code Marketplace ?"
+        required: true
+        type: choice
+        options:
+          - "true"
+          - "false"
+        default: "false"
+      publishToOVSX:
+        description: "Publish to OpenVSX Registry ?"
+        required: true
+        type: choice
+        options:
+          - "true"
+          - "false"
+        default: "false"
+
 jobs:
   should-build-change:
     runs-on: ubuntu-latest
     outputs:
-        repo-cache-hit: ${{ steps.cache-last-commit.outputs.cache-hit }}
+      repo-cache-hit: ${{ steps.cache-last-commit.outputs.cache-hit }}
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: 'eclipse/lemminx'
+          repository: "eclipse/lemminx"
           fetch-depth: 2
           path: lemminx
       - uses: actions/checkout@v4
         with:
-          repository: 'redhat-developer/vscode-xml'
+          repository: "redhat-developer/vscode-xml"
           fetch-depth: 2
           path: vscode-xml
       - run: |
@@ -57,12 +58,14 @@ jobs:
         with:
           path: lastCommit
           key: lastCommit-${{ hashFiles('lastCommit') }}
+
   build-binaries-job:
     needs: should-build-change
     if: ${{ needs.should-build-change.outputs.repo-cache-hit != 'true' || github.event_name != 'schedule' }}
     uses: redhat-developer/vscode-xml/.github/workflows/native-image.yaml@main
     with:
       publishPreRelease: ${{ github.event_name == 'schedule' || inputs.publishPreRelease == 'true' }}
+
   packaging-job:
     runs-on: ubuntu-latest
     needs: build-binaries-job
@@ -83,7 +86,7 @@ jobs:
       - name: Set Up NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: "18"
       - name: Install dependencies
         run: npm install -g typescript "@vscode/vsce" "ovsx"
       - name: Build vscode-xml
@@ -101,12 +104,13 @@ jobs:
           echo "EXT_VERSION=$(cat package.json | jq -r .version)" >> $GITHUB_ENV
       - name: Download LemMinX Server Uber Jar
         env:
-            downloadLocation: https://github.com/redhat-developer/vscode-xml
+          downloadLocation: https://github.com/redhat-developer/vscode-xml
         if: "${{ inputs.publishToMarketPlace == 'true' || inputs.publishToOVSX == 'true' }}"
         run: |
           curl -Lo org.eclipse.lemminx-${{ env.XML_SERVER_VERSION }}-uber.jar https://repo.eclipse.org/content/repositories/lemminx-releases/org/eclipse/lemminx/org.eclipse.lemminx/${{ env.XML_SERVER_VERSION }}/org.eclipse.lemminx-${{ env.XML_SERVER_VERSION }}-uber.jar
           sed -i -e "s|${{ env.downloadLocation }}/releases/download/latest|${{ env.downloadLocation }}/releases/download/${{ env.EXT_VERSION }}|g" package.json
-      - run: |
+      - name: Copy Uber Jar to server/
+        run: |
           mkdir server/
           if [ -e org.eclipse.lemminx*-uber.jar ]; then
             mv org.eclipse.lemminx*-uber.jar server/
@@ -116,7 +120,7 @@ jobs:
       - name: Download LemMinX Binary Artifacts
         uses: actions/download-artifact@v4
       - name: Prepare Binary Artifacts For Packaging
-        run:  |
+        run: |
           mkdir -p ../staging/zips ../staging/checksums
           for f in lemminx-linux lemminx-osx-{x86_64,aarch_64} lemminx-win32; do
             pushd ${f}
@@ -177,6 +181,7 @@ jobs:
             vscode-xml*-${{ env.EXT_VERSION }}-${{ github.run_number }}.vsix
             ../staging/zips/lemminx-*
             ../staging/checksums/lemminx-*
+
   release-job:
     environment: ${{ (inputs.publishToMarketPlace == 'true' || inputs.publishToOVSX == 'true') && 'release' || 'pre-release' }}
     runs-on: ubuntu-latest
@@ -187,7 +192,7 @@ jobs:
       - name: Set Up NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "20"
       - name: Install dependencies
         run: npm install -g typescript "@vscode/vsce" "ovsx"
       - name: Download VSIX & LemMinX Server Uber Jar


### PR DESCRIPTION
I wouldn't normally submit a whitespace formatting PR to a project as a first contribution but the fact that all of `.github/workflows/native-image.yaml` was indented two extras spaces was just a bit too much for me.

Feel free to summarily close without a comment if this is unwelcome.

Changes:
- Formatted with prettier
- Added yaml/yml to .editorconfig
- Added name for `Copy Uber Jar to server/` step
- Added spaces between jobs to increase legibility