### PR TITLE
Do not format text content of `<style>` and `<script>`

### DIFF
--- a/package.json
+++ b/package.json
@@ -371,7 +371,9 @@
             "screen",
             "synopsis",
             "pre",
-            "xd:pre"
+            "xd:pre",
+            "style",
+            "script"
           ],
           "items": {
             "type": "string"


### PR DESCRIPTION
Usually `<style>` contains CSS and `<script>` contains JavaScript (or some other scripting language), so the text content is probably manually formatted, and the whitespace shouldn't be adjusted.

Fixes #1104