### PR TITLE
Smoke test all binaries using matrix build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,43 +16,42 @@ jobs:
     - name: Run ESLint
       run: npm run eslint
 
-  build-test-native-image:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        repository: 'eclipse/lemminx'
-    - uses: graalvm/setup-graalvm@557ffcf459751b4d92319ee255bf3bec9b73964c #v1.2.5
-      with:
-        distribution: graalvm-community
-        java-version: 17
-    - run: ./mvnw -B package -Dnative -DskipTests -Dgraalvm.static=-H:+StaticExecutableWithDynamicLibC -Dcbi.jarsigner.skip=true
-    - run: mv org.eclipse.lemminx/target/lemminx-* lemminx-linux
-    - uses: actions/upload-artifact@v4
-      with:
-        name: lemminx-linux
-        path: lemminx-linux
-        if-no-files-found: error
+  matrix-smoke-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        label: [linux-x86_64, linux-aarch_64, osx-x86_64, osx-aarch_64]
+        include:
+          - label: linux-x86_64
+            os: ubuntu-latest
+            startx: xvfb-run
+            graalOpt: -Dgraalvm.static=-H:+StaticExecutableWithDynamicLibC
+          - label: linux-aarch_64
+            os: ubuntu-24.04-arm
+            startx: xvfb-run
+            graalOpt: -Dgraalvm.static=-H:+StaticExecutableWithDynamicLibC
+          - label: osx-x86_64
+            os: macos-15-intel
+          - label: osx-aarch_64
+            os: macos-latest
+    uses: ./.github/workflows/smoke-test.yaml
+    with:
+      os: ${{ matrix.os }}
+      label: ${{ matrix.label }}
+      graalOpt: ${{ matrix.graalOpt }}
+      startx: ${{ matrix.startx }}
+    secrets: inherit
 
-  smoke-test:
-    runs-on: ubuntu-latest
-    needs: build-test-native-image
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-        with:
-          name: lemminx-linux
-          path: server
-      - name: Make lemminx binary executable
-        run: chmod u+x ./server/lemminx-linux
-      - name: Make lemminx binary trusted
-        run: sha256sum ./server/lemminx-linux > ./server/lemminx-linux.sha256
-      - name: Install dependencies
-        run: npm i --also=dev
-      - name: Run smoke test suite
-        run: xvfb-run npm test
-      - name: Delete lemminx binary
-        if: always()
-        uses: geekyeggo/delete-artifact@e46cfb9575865f907c2beb2e4170b5f4c7d77c52
-        with:
-          name: lemminx-linux
+  matrix-smoke-test-windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        label: [win32]
+        include:
+          - label: win32
+            os: windows-latest
+    uses: ./.github/workflows/smoke-test-windows.yaml
+    with:
+      os: ${{ matrix.os }}
+      label: ${{ matrix.label }}
+    secrets: inherit

--- a/.github/workflows/smoke-test-windows.yaml
+++ b/.github/workflows/smoke-test-windows.yaml
@@ -1,0 +1,53 @@
+name: Smoke test (Windows)
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      label:
+        required: true
+        type: string
+
+jobs:
+  build-test-native-image:
+    runs-on: ${{ inputs.os }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: 'eclipse/lemminx'
+    - uses: graalvm/setup-graalvm@557ffcf459751b4d92319ee255bf3bec9b73964c #v1.2.5
+      with:
+        distribution: graalvm-community
+        java-version: 17
+    - run: .\mvnw.cmd -B package -Dnative -DskipTests -D "cbi.jarsigner.skip=true"
+    - run: mv org.eclipse.lemminx\target\lemminx-* lemminx-${{ inputs.label }}.exe
+    - uses: actions/upload-artifact@v4
+      with:
+        name: lemminx-${{ inputs.label }}
+        path: lemminx-${{ inputs.label }}.exe
+        if-no-files-found: error
+
+  smoke-test:
+    runs-on: ${{ inputs.os }}
+    needs: build-test-native-image
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: lemminx-${{ inputs.label }}
+          path: server
+      - name: Make lemminx binary trusted
+        run: certUtil -hashfile .\server\lemminx-${{ inputs.label }}.exe SHA256 | findstr /v "hash" > .\server\lemminx-${{ inputs.label }}.sha256
+      - name: show hash
+        run: type .\server\lemminx-${{ inputs.label }}.sha256
+      - name: Install dependencies
+        run: npm i --also=dev
+      - name: Run smoke test suite
+        run: npm test
+      - name: Delete lemminx binary
+        if: always()
+        uses: geekyeggo/delete-artifact@e46cfb9575865f907c2beb2e4170b5f4c7d77c52
+        with:
+          name: lemminx-${{ inputs.label }}

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -1,0 +1,59 @@
+name: Smoke test
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      label:
+        required: true
+        type: string
+      graalOpt:
+        required: false
+        type: string
+      startx:
+        required: false
+        type: string
+
+jobs:
+  build-test-native-image:
+    runs-on: ${{ inputs.os }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: 'eclipse/lemminx'
+    - uses: graalvm/setup-graalvm@557ffcf459751b4d92319ee255bf3bec9b73964c #v1.2.5
+      with:
+        distribution: graalvm-community
+        java-version: 17
+    - run: ./mvnw -B package -Dnative -DskipTests ${{ inputs.graalOpt }} -Dcbi.jarsigner.skip=true
+    - run: mv org.eclipse.lemminx/target/lemminx-* lemminx-${{ inputs.label }}
+    - uses: actions/upload-artifact@v4
+      with:
+        name: lemminx-${{ inputs.label }}
+        path: lemminx-${{ inputs.label }}
+        if-no-files-found: error
+
+  smoke-test:
+    runs-on: ${{ inputs.os }}
+    needs: build-test-native-image
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: lemminx-${{ inputs.label }}
+          path: server
+      - name: Make lemminx binary executable
+        run: chmod u+x ./server/lemminx-${{ inputs.label }}
+      - name: Make lemminx binary trusted
+        run: openssl sha256 ./server/lemminx-${{ inputs.label }} | awk '{print $2}' > ./server/lemminx-${{ inputs.label }}.sha256
+      - name: Install dependencies
+        run: npm i --also=dev
+      - name: Run smoke test suite
+        run: ${{ inputs.startx }} npm test
+      - name: Delete lemminx binary
+        if: always()
+        uses: geekyeggo/delete-artifact@e46cfb9575865f907c2beb2e4170b5f4c7d77c52
+        with:
+          name: lemminx-${{ inputs.label }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,10 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-	"files.exclude": {
-		"out": false // set this to true to hide the "out" folder with the compiled JS files
-	},
-	"search.exclude": {
-		"out": true // set this to false to include "out" folder in search results
-	},
-    "typescript.tsdk": "./node_modules/typescript/lib",
+  "files.exclude": {
+    "out": false // set this to true to hide the "out" folder with the compiled JS files
+  },
+  "search.exclude": {
+    "out": true // set this to false to include "out" folder in search results
+  },
+  "js/ts.tsdk.path": "./node_modules/typescript/lib",
 }

--- a/src/server/binary/binaryServerStarter.ts
+++ b/src/server/binary/binaryServerStarter.ts
@@ -213,13 +213,22 @@ function getBinaryEnvironment(): any {
  */
 function getServerBinaryNameWithoutExtension(): string {
   switch (os.platform()) {
-    case 'darwin':
+    case 'darwin': {
       switch (os.arch()) {
         case 'arm64':
           return 'lemminx-osx-aarch_64';
         default:
           return 'lemminx-osx-x86_64';
       }
+    }
+    case 'linux': {
+      switch (os.arch()) {
+        case 'arm64':
+          return 'lemminx-linux-aarch_64';
+        default:
+          return 'lemminx-linux-x86_64';
+      }
+    }
     default:
       return `lemminx-${os.platform()}`;
   }

--- a/src/test/smoke.test.ts
+++ b/src/test/smoke.test.ts
@@ -19,7 +19,7 @@ suite('Smoke tests', function () {
   this.timeout(10_000);
 
   // diagnostics take some time to appear; the language server must be started and respond to file open event
-  const DIAGNOSTICS_DELAY = 4_000;
+  const DIAGNOSTICS_DELAY = 6_000;
 
   const SCHEMA = `<?xml version="1.0" encoding="UTF-8"?>
     <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"


### PR DESCRIPTION
This lets us smoke test the binaries for every platform instead of just linux x86_64.

The builds are run in parallel, which looks a bit messy in the output but hopefully will mean it takes around 10 minutes to get all the results.

I wrote the windows part so that it can be expanded to include arm64 in the future.

Also fixes a bug preventing the linux arm64 binary from being used.