### PR TITLE
Update version of Intel macOS in release build

### DIFF
--- a/.github/workflows/native-image.yaml
+++ b/.github/workflows/native-image.yaml
@@ -29,7 +29,7 @@
           label: [osx-x86_64, osx-aarch_64, linux-x86_64, linux-aarch_64]
           include:
             - label: osx-x86_64
-              os: macos-13
+              os: macos-latest-large
             - label: osx-aarch_64
               os: macos-latest
             - label: linux-x86_64


### PR DESCRIPTION
macOS 13 runners are no longer available. macos-latest-large points to the latest available Intel macOS