### PR TITLE
Fix/xml encoding detection encoding

### DIFF
--- a/src/client/xmlEncoding.ts
+++ b/src/client/xmlEncoding.ts
@@ -1,0 +1,145 @@
+/**
+ *  Copyright (c) 2026 Red Hat, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-v20.html
+ *
+ *  Contributors:
+ *  Red Hat Inc. - initial API and implementation
+ */
+
+import { ExtensionContext, TextDocument, window, workspace } from 'vscode';
+
+const XML_TO_VSCODE_ENCODING = new Map<string, string>([
+  ['utf-8', 'utf8'],
+  ['us-ascii', 'utf8'],
+  ['ascii', 'utf8'],
+  ['utf-16', 'utf16le'],
+  ['utf-16le', 'utf16le'],
+  ['utf-16be', 'utf16be'],
+  ['iso-8859-1', 'iso88591'],
+  ['iso-8859-2', 'iso88592'],
+  ['iso-8859-3', 'iso88593'],
+  ['iso-8859-4', 'iso88594'],
+  ['iso-8859-5', 'iso88595'],
+  ['iso-8859-6', 'iso88596'],
+  ['iso-8859-7', 'iso88597'],
+  ['iso-8859-8', 'iso88598'],
+  ['iso-8859-9', 'iso88599'],
+  ['iso-8859-10', 'iso885910'],
+  ['iso-8859-11', 'iso885911'],
+  ['iso-8859-13', 'iso885913'],
+  ['iso-8859-14', 'iso885914'],
+  ['iso-8859-15', 'iso885915'],
+  ['iso-8859-16', 'iso885916'],
+  ['windows-1250', 'windows1250'],
+  ['windows-1251', 'windows1251'],
+  ['windows-1252', 'windows1252'],
+  ['windows-1253', 'windows1253'],
+  ['windows-1254', 'windows1254'],
+  ['windows-1255', 'windows1255'],
+  ['windows-1256', 'windows1256'],
+  ['windows-1257', 'windows1257'],
+  ['windows-1258', 'windows1258'],
+  ['shift_jis', 'shiftjis'],
+  ['shift-jis', 'shiftjis'],
+  ['euc-jp', 'eucjp'],
+  ['euc-kr', 'euckr'],
+  ['gb2312', 'gb2312'],
+  ['gbk', 'gbk'],
+  ['gb18030', 'gb18030'],
+  ['big5', 'big5hkscs'],
+  ['big5-hkscs', 'big5hkscs'],
+  ['koi8-r', 'koi8r'],
+  ['koi8-u', 'koi8u'],
+  ['latin1', 'iso88591'],
+  ['latin-1', 'iso88591'],
+]);
+
+/**
+ * Parse the encoding from an XML prolog on the first line.
+ * Uses manual scanning (no regex) for maximum performance.
+ *
+ * @param firstLine the first line of the document
+ * @returns the encoding value in lowercase, or undefined if not found
+ */
+export function parseXmlEncoding(firstLine: string): string | undefined {
+  if (firstLine.length < 6 || firstLine.charCodeAt(0) !== 0x3C || firstLine.charCodeAt(1) !== 0x3F) {
+    return undefined;
+  }
+
+  const prologEnd = firstLine.indexOf('?>');
+  if (prologEnd === -1) return undefined;
+
+  const encodingIdx = firstLine.indexOf('encoding', 2);
+  if (encodingIdx === -1 || encodingIdx >= prologEnd) return undefined;
+
+  let i = encodingIdx + 8; // 'encoding'.length
+
+  while (i < prologEnd && (firstLine.charCodeAt(i) === 0x20 || firstLine.charCodeAt(i) === 0x09)) i++;
+  if (i >= prologEnd || firstLine.charCodeAt(i) !== 0x3D) return undefined;
+  i++;
+  while (i < prologEnd && (firstLine.charCodeAt(i) === 0x20 || firstLine.charCodeAt(i) === 0x09)) i++;
+
+  const quoteChar = firstLine.charCodeAt(i);
+  if (quoteChar !== 0x22 && quoteChar !== 0x27) return undefined;
+  i++;
+
+  const valueStart = i;
+  while (i < prologEnd && firstLine.charCodeAt(i) !== quoteChar) i++;
+  if (i >= prologEnd) return undefined;
+
+  return firstLine.substring(valueStart, i).toLowerCase();
+}
+
+export function activateXmlEncodingDetection(context: ExtensionContext, supportedLanguageIds: string[]): void {
+  const languageIdSet = new Set(supportedLanguageIds);
+  let encodingApiAvailable: boolean | undefined;
+
+  const checkAndFixEncoding = async (document: TextDocument): Promise<void> => {
+    // Check once if the encoding API is available (VS Code 1.100+)
+    if (encodingApiAvailable === undefined) {
+      encodingApiAvailable = 'encoding' in document;
+    }
+    if (!encodingApiAvailable) return;
+
+    // Only handle XML-type documents from the local file system
+    if (!languageIdSet.has(document.languageId)) return;
+    if (document.uri.scheme !== 'file') return;
+    // Cannot change encoding on a dirty document (VS Code API constraint)
+    if (document.isDirty) return;
+    if (document.lineCount === 0) return;
+
+    // Parse the encoding declared in the XML prolog (e.g. encoding="ISO-8859-1")
+    const xmlEncoding = parseXmlEncoding(document.lineAt(0).text);
+    if (!xmlEncoding) return;
+
+    // Skip if encoding already matches or is unknown
+    const targetEncoding = XML_TO_VSCODE_ENCODING.get(xmlEncoding);
+    if (!targetEncoding || targetEncoding === (document as any).encoding) return;
+
+    // Reopen the document with the correct encoding
+    try {
+      await (workspace.openTextDocument as any)(document.uri, { encoding: targetEncoding });
+    } catch {
+      // Document may have become dirty between our check and the reopen call
+    }
+  };
+
+  context.subscriptions.push(
+    // Use onDidChangeActiveTextEditor instead of onDidOpenTextDocument to avoid
+    // race conditions with the language client initialization resetting encoding
+    window.onDidChangeActiveTextEditor(editor => {
+      if (editor) {
+        checkAndFixEncoding(editor.document);
+      }
+    }),
+    workspace.onDidSaveTextDocument(checkAndFixEncoding)
+  );
+
+  // Check the currently active editor
+  if (window.activeTextEditor) {
+    checkAndFixEncoding(window.activeTextEditor.document);
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import { XMLExtensionApi } from './api/xmlExtensionApi';
 import { getXmlExtensionApiImplementation } from './api/xmlExtensionApiImplementation';
 import { cleanUpHeapDumps } from './client/clientErrorHandler';
 import { getIndentationRules } from './client/indentation';
+import { activateXmlEncodingDetection } from './client/xmlEncoding';
 import { XML_SUPPORTED_LANGUAGE_IDS, startLanguageClient } from './client/xmlClient';
 import { registerClientOnlyCommands } from './commands/registerCommands';
 import { collectXmlJavaExtensions } from './plugin';
@@ -41,6 +42,9 @@ export async function activate(context: ExtensionContext): Promise<XMLExtensionA
 
   // Register in the context 'xml.supportedLanguageIds' to use it in command when condition in package.json
   commands.executeCommand('setContext', 'xml.supportedLanguageIds', XML_SUPPORTED_LANGUAGE_IDS);
+
+  // Detect XML encoding from prolog and reopen with correct encoding if needed
+  activateXmlEncodingDetection(context, XML_SUPPORTED_LANGUAGE_IDS);
 
   let requirementsData: requirements.RequirementsData;
   try {

--- a/src/test/xmlEncoding.test.ts
+++ b/src/test/xmlEncoding.test.ts
@@ -1,0 +1,81 @@
+/**
+ *  Copyright (c) 2026 Red Hat, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-v20.html
+ *
+ *  Contributors:
+ *  Red Hat Inc. - initial API and implementation
+ */
+import * as assert from 'assert';
+import { parseXmlEncoding } from '../client/xmlEncoding';
+
+suite('XML Encoding Detection', function () {
+
+  test('detects UTF-8 encoding', function () {
+    assert.strictEqual(parseXmlEncoding('<?xml version="1.0" encoding="UTF-8"?>'), 'utf-8');
+  });
+
+  test('detects ISO-8859-1 encoding', function () {
+    assert.strictEqual(parseXmlEncoding('<?xml version="1.0" encoding="ISO-8859-1"?>'), 'iso-8859-1');
+  });
+
+  test('detects encoding with single quotes', function () {
+    assert.strictEqual(parseXmlEncoding("<?xml version='1.0' encoding='UTF-8'?>"), 'utf-8');
+  });
+
+  test('detects encoding with spaces around =', function () {
+    assert.strictEqual(parseXmlEncoding('<?xml version="1.0" encoding = "UTF-8"?>'), 'utf-8');
+  });
+
+  test('detects encoding with tabs around =', function () {
+    assert.strictEqual(parseXmlEncoding('<?xml version="1.0" encoding\t=\t"UTF-8"?>'), 'utf-8');
+  });
+
+  test('returns undefined for no encoding attribute', function () {
+    assert.strictEqual(parseXmlEncoding('<?xml version="1.0"?>'), undefined);
+  });
+
+  test('returns undefined for non-XML content', function () {
+    assert.strictEqual(parseXmlEncoding('<root>content</root>'), undefined);
+  });
+
+  test('returns undefined for empty string', function () {
+    assert.strictEqual(parseXmlEncoding(''), undefined);
+  });
+
+  test('returns undefined for short string', function () {
+    assert.strictEqual(parseXmlEncoding('<?xml'), undefined);
+  });
+
+  test('returns undefined when prolog is not closed', function () {
+    assert.strictEqual(parseXmlEncoding('<?xml version="1.0" encoding="UTF-8"'), undefined);
+  });
+
+  test('detects Windows-1252 encoding', function () {
+    assert.strictEqual(parseXmlEncoding('<?xml version="1.0" encoding="Windows-1252"?>'), 'windows-1252');
+  });
+
+  test('detects Shift_JIS encoding', function () {
+    assert.strictEqual(parseXmlEncoding('<?xml version="1.0" encoding="Shift_JIS"?>'), 'shift_jis');
+  });
+
+  test('handles encoding as first attribute', function () {
+    assert.strictEqual(parseXmlEncoding('<?xml encoding="UTF-8" version="1.0"?>'), 'utf-8');
+  });
+
+  test('normalizes encoding to lowercase', function () {
+    assert.strictEqual(parseXmlEncoding('<?xml version="1.0" encoding="UTF-8"?>'), 'utf-8');
+    assert.strictEqual(parseXmlEncoding('<?xml version="1.0" encoding="Utf-8"?>'), 'utf-8');
+    assert.strictEqual(parseXmlEncoding('<?xml version="1.0" encoding="utf-8"?>'), 'utf-8');
+  });
+
+  test('ignores encoding outside of prolog', function () {
+    assert.strictEqual(parseXmlEncoding('<?xml version="1.0"?> encoding="UTF-8"'), undefined);
+  });
+
+  test('handles prolog with standalone attribute', function () {
+    assert.strictEqual(parseXmlEncoding('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'), 'utf-8');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #759

Detect the `encoding` attribute from the XML prolog (e.g. `<?xml version="1.0" encoding="ISO-8859-1"?>`) and automatically reopen the document with the correct encoding.

This encoding detection is applied:
- **On file open**: when an XML document is opened, the extension parses the prolog and reopens the file with the declared encoding if it differs from the current one.
- **On file save**: when an XML document is saved, the extension re-checks the prolog encoding, handling the case where the user changed the encoding declaration.

The feature uses the `TextDocument.encoding` API introduced in VS Code 1.100. On older versions, the detection is gracefully skipped (no error, no overhead).

### Demo

Here is a demo:

<img width="939" height="490" alt="VscodeXMLEncoding" src="https://github.com/user-attachments/assets/c213ca2e-b111-49f2-927b-68b49b5c0bb1" />

## Test plan

- [ ] Open an XML file with `encoding="ISO-8859-1"` -> verify the file is automatically reopened with the correct encoding
- [ ] Open an XML file with `encoding="UTF-8"` -> verify no reopen occurs
- [ ] Open an XML file without encoding attribute -> verify no reopen occurs
- [ ] Edit the prolog encoding and save ->  verify the file is reopened with the new encoding
- [ ] Open a non-XML file ->  verify no encoding detection occurs
- [ ] Run on VS Code < 1.100 -> verify no error occurs
