### PR TITLE
Add 'Ignore Formatting' surround with command

### DIFF
--- a/package.json
+++ b/package.json
@@ -843,6 +843,11 @@
         "category": "XML"
       },
       {
+        "command": "xml.refactor.surround.with.ignoreFormatting",
+        "title": "Ignore Formatting",
+        "category": "XML"
+      },
+      {
         "command": "xml.minify",
         "title": "Minify XML Document",
         "category": "XML"
@@ -879,6 +884,10 @@
           "when": "editorLangId in xml.supportedLanguageIds && XMLLSReady"
         },
         {
+          "command": "xml.refactor.surround.with.ignoreFormatting",
+          "when": "editorLangId in xml.supportedLanguageIds && XMLLSReady"
+        },
+        {
           "command": "xml.minify",
           "when": "editorLangId in xml.supportedLanguageIds && XMLLSReady"
         }
@@ -896,6 +905,11 @@
         },
         {
           "command": "xml.refactor.surround.with.cdata",
+          "when": "editorLangId in xml.supportedLanguageIds && XMLLSReady",
+          "group": "1_modification"
+        },
+        {
+          "command": "xml.refactor.surround.with.ignoreFormatting",
           "when": "editorLangId in xml.supportedLanguageIds && XMLLSReady",
           "group": "1_modification"
         }

--- a/src/commands/clientCommandConstants.ts
+++ b/src/commands/clientCommandConstants.ts
@@ -76,6 +76,8 @@ export const EXECUTE_WORKSPACE_COMMAND = 'xml.workspace.executeCommand';
 
  export const REFACTOR_SURROUND_WITH_CDATA = 'xml.refactor.surround.with.cdata';
 
+ export const REFACTOR_SURROUND_WITH_IGNORE_FORMATTING = 'xml.refactor.surround.with.ignoreFormatting';
+
 /**
  * Command to minify XML document.
  */

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -387,6 +387,7 @@ class SurroundWithKind {
   static readonly tags = 'tags';
   static readonly comments = 'comments';
   static readonly cdata = 'cdata';
+  static readonly ignoreFormatting = 'ignoreFormatting';
 
 }
 
@@ -411,6 +412,11 @@ function registerRefactorCommands(context: ExtensionContext, languageClient: Lan
   // Surround with CDATA
   context.subscriptions.push(commands.registerCommand(ClientCommandConstants.REFACTOR_SURROUND_WITH_CDATA, async () => {
     await surroundWith(SurroundWithKind.cdata, languageClient);
+  }));
+
+  // Ignore Formatting
+  context.subscriptions.push(commands.registerCommand(ClientCommandConstants.REFACTOR_SURROUND_WITH_IGNORE_FORMATTING, async () => {
+    await surroundWith(SurroundWithKind.ignoreFormatting, languageClient);
   }));
 }
 


### PR DESCRIPTION
Register a new surround with command that wraps selected XML content with formatter off/on comments via the LemMinX language server.

This PR requires https://github.com/eclipse-lemminx/lemminx/pull/1848

Here a demo:

<img width="939" height="489" alt="IgnoreFormatting" src="https://github.com/user-attachments/assets/647bb09b-4cec-4a7b-9255-c348cbb574a1" />
